### PR TITLE
Bugfix: Reader throws DivideByZeroException when articleTitle is empty

### DIFF
--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -582,25 +582,28 @@ namespace SmartReader
             // If there is only one h2 and its text content substantially equals article title,
             // they are probably using it as a header and not a subheader,
             // so remove it since we already extract the title separately.
-            var h2 = articleContent.GetElementsByTagName("h2");
-            if (h2.Length == 1)
+            if (articleTitle.Length > 0)
             {
-                var lengthSimilarRate = (h2[0].TextContent.Length - articleTitle.Length) / articleTitle.Length;
-
-                if (Math.Abs(lengthSimilarRate) < 0.5)
+                var h2 = articleContent.GetElementsByTagName("h2");
+                if (h2.Length == 1)
                 {
-                    var titlesMatch = false;
-                    if (lengthSimilarRate > 0)
+                    var lengthSimilarRate = (h2[0].TextContent.Length - articleTitle.Length) / articleTitle.Length;
+
+                    if (Math.Abs(lengthSimilarRate) < 0.5)
                     {
-                        titlesMatch = h2[0].TextContent.Contains(articleTitle);
-                    }
-                    else
-                    {
-                        titlesMatch = articleTitle.Contains(h2[0].TextContent);
-                    }
-                    if (titlesMatch)
-                    {
-                        Clean(articleContent, "h2");
+                        var titlesMatch = false;
+                        if (lengthSimilarRate > 0)
+                        {
+                            titlesMatch = h2[0].TextContent.Contains(articleTitle);
+                        }
+                        else
+                        {
+                            titlesMatch = articleTitle.Contains(h2[0].TextContent);
+                        }
+                        if (titlesMatch)
+                        {
+                            Clean(articleContent, "h2");
+                        }
                     }
                 }
             }

--- a/src/SmartReaderTests/PagesTests.cs
+++ b/src/SmartReaderTests/PagesTests.cs
@@ -97,7 +97,7 @@ namespace SmartReaderTests
             Assert.Equal(expected.Excerpt, found.Excerpt);
             Assert.Equal(expected.SiteName, found.SiteName);
             Assert.Equal(expected.TimeToRead, found.TimeToRead);
-            Assert.Equal(expected.Content, found.Content);
+            Assert.Equal(expected.Content, found.Content, ignoreLineEndingDifferences: true);
             Assert.Equal(expected.FeaturedImage, found.FeaturedImage);
         }
 

--- a/src/SmartReaderTests/test-pages/no-head/expected-metadata.json
+++ b/src/SmartReaderTests/test-pages/no-head/expected-metadata.json
@@ -1,0 +1,13 @@
+{
+  "title": "",
+  "byline": "",
+  "dir": "",
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\n    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  "readerable": false,
+  "language": null,
+  "timeToRead": "00:01:00",
+  "publicationDate": null,
+  "author": null,
+  "siteName": "",
+  "featuredImage": ""
+}

--- a/src/SmartReaderTests/test-pages/no-head/expected.html
+++ b/src/SmartReaderTests/test-pages/no-head/expected.html
@@ -1,0 +1,19 @@
+<div id="readability-page-1" class="page"><article>
+  
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </p>
+  <h2>Foo</h2>
+  <p>
+    Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </p>
+</article></div>

--- a/src/SmartReaderTests/test-pages/no-head/source.html
+++ b/src/SmartReaderTests/test-pages/no-head/source.html
@@ -1,0 +1,19 @@
+<article>
+  <h1>Lorem</h1>
+  <div>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </div>
+  <h2>Foo</h2>
+  <div>
+    Tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </div>
+</article>


### PR DESCRIPTION
`SmartReader.Reader.PrepArticle` throws `DivideByZeroException` when `articleTitle` is empty.

`articleTitle` can be empty when the HTML has no `<head>`-Element.

JavaScript does not throw an exception, instead NaN ist returned. Any comparision with NaN (`Math.abs(lengthSimilarRate) < 0.5`) will be false

With this change the whole h2 segment will be skipped when `articleTitle` is empty.

Additionally, I added a test page which will cause `articleTitle` to be empty and containing a h2 to trigger this code segment.

Also almost all tests failed because of different line endings in article contents. Therefore I enabled `ignoreLineEndingDifferences` on `Assert.Equal(expected.Content, found.Content)`

JavaScript code for reference: https://github.com/mozilla/readability/blob/master/Readability.js#L694