### PR TITLE
Improve Code Quality 2

### DIFF
--- a/src/SmartReader/Article.cs
+++ b/src/SmartReader/Article.cs
@@ -163,18 +163,18 @@ namespace SmartReader
             {
                 foreach (var img in imgs)
                 {
-                    if (!string.IsNullOrEmpty(img.GetAttribute("src")))
+                    if (img.GetAttribute("src") is { Length: > 0 } src)
                     {
                         long size = 0;
 
-                        var imageUri = new Uri(img.GetAttribute("src"));
+                        var imageUri = new Uri(src);
 
                         try
                         {
                             imageUri = new Uri(Uri.ToAbsoluteURI(imageUri.ToString()));
                             size = await _reader!.GetImageSizeAsync(imageUri);
                         }
-                        catch (Exception e) { }
+                        catch { }
 
                         string description = img.GetAttribute("alt");
                         string title = img.GetAttribute("title");

--- a/src/SmartReader/Article.cs
+++ b/src/SmartReader/Article.cs
@@ -38,9 +38,9 @@ namespace SmartReader
         /// <value>The language provided by the metadata</value>
         public string Language { get; private set; }
         /// <value>The author, which can be parsed or read in the metadata</value>
-        public string Author { get; private set; }
+        public string? Author { get; private set; }
         /// <value>The name of the website, which can be parsed or read in the metadata </value>
-        public string SiteName { get; private set; }
+        public string? SiteName { get; private set; }
         /// <value>The length in bytes of <c>Content</c></value>
         public int Length { get; private set; }
         /// <value>The average time to read</value>
@@ -58,10 +58,10 @@ namespace SmartReader
         /// <value>Default: return InnerHTML property</value>       
         public static Func<IElement, string> Converter { get; set; } = ConvertToPlaintext;
 
-        private readonly IElement _article = null;
-        private readonly  Reader _reader;
+        private readonly IElement? _article = null;
+        private readonly Reader? _reader;
 
-        internal Article(Uri uri, string title, string byline, string dir, string language, string author, IElement article, Metadata metadata, bool readable, Reader reader)
+        internal Article(Uri uri, string title, string byline, string dir, string language, string? author, IElement article, Metadata metadata, bool readable, Reader reader)
         {
             Uri = uri;
             Title = title;
@@ -114,7 +114,7 @@ namespace SmartReader
                 if (!string.IsNullOrWhiteSpace(Language))
                     culture = new CultureInfo(Language);
             }
-            catch(CultureNotFoundException)
+            catch (CultureNotFoundException)
             { }
 
             var cpm = charactersMinute.FirstOrDefault(x => culture.EnglishName.StartsWith(x.Key, StringComparison.Ordinal));
@@ -172,7 +172,7 @@ namespace SmartReader
                         try
                         {
                             imageUri = new Uri(Uri.ToAbsoluteURI(imageUri.ToString()));
-                            size = await _reader.GetImageSizeAsync(imageUri);
+                            size = await _reader!.GetImageSizeAsync(imageUri);
                         }
                         catch (Exception e) { }
 
@@ -194,7 +194,7 @@ namespace SmartReader
 
                 // if there is no featured image, let's set the first one we found
                 if (string.IsNullOrEmpty(FeaturedImage) && images.Count > 0)
-                    FeaturedImage = images[0].Source.ToString();
+                    FeaturedImage = images[0].Source!.ToString();
             }
 
             return images;
@@ -209,38 +209,35 @@ namespace SmartReader
         /// </returns>  
         public async Task ConvertImagesToDataUriAsync(long minSize = 75000)
         {
-            var imgs = _article?.QuerySelectorAll("img");            
+            if (_article is null) return;
 
-            if (imgs != null)
+            foreach (var img in _article.QuerySelectorAll("img"))
             {
-                foreach (var img in imgs)
+                if (img.GetAttribute("src") is string src)
                 {
-                    if (img.GetAttribute("src") is string src)
+                    var imageUri = new Uri(src);
+
+                    try
                     {
-                        var imageUri = new Uri(src);
+                        // download image
+                        byte[] bytes = await _reader!.GetImageBytesAsync(imageUri).ConfigureAwait(false);
 
-                        try
+                        if (bytes.LongLength > minSize)
                         {
-                            // download image
-                            byte[] bytes = await _reader.GetImageBytesAsync(imageUri);
-
-                            if (bytes.LongLength > minSize)
-                            {
-                                // convert it to data uri scheme and replace the original source
-                                img.SetAttribute("src", Image.ConvertImageToDataUri(imageUri.AbsolutePath, bytes));
-                            }
-                            else
-                            {
-                                img.Remove();
-                            }                            
+                            // convert it to data uri scheme and replace the original source
+                            img.SetAttribute("src", Image.ConvertImageToDataUri(imageUri.AbsolutePath, bytes));
                         }
-                        catch (Exception e) { }                                                
+                        else
+                        {
+                            img.Remove();
+                        }                            
                     }
+                    catch { }                                                
                 }
-
-                // we update the affected properties
-                Content = _article.InnerHtml;
             }
+
+            // we update the affected properties
+            Content = _article.InnerHtml;            
         }
 
         /// <summary>
@@ -316,7 +313,7 @@ namespace SmartReader
                     // if the element has other elements we look inside of them
                     if (el.NodeType == NodeType.Element
                         || el.NodeType == NodeType.EntityReference)
-                        ConvertToText(el as IElement, text);
+                        ConvertToText((IElement)el, text);
                     // if the element has children text nodes we extract the text
                     if (el.NodeType == NodeType.Text)
                         text.Write(el.TextContent);

--- a/src/SmartReader/Image.cs
+++ b/src/SmartReader/Image.cs
@@ -2,6 +2,8 @@
 
 using System;
 
+using AngleSharp.Io;
+
 namespace SmartReader
 {
     /// <summary>
@@ -25,7 +27,12 @@ namespace SmartReader
         /// <param name="bytes">The actual binary content of the image</param>
         internal static string ConvertImageToDataUri(string path, byte[] bytes)
         {
-            return $"data:{MimeMapping.MimeUtility.GetMimeMapping(path)};base64,{Convert.ToBase64String(bytes)}";
+            int dotIndex = path.IndexOf('.');
+            string extension = dotIndex > 0 ? path.Substring(dotIndex) : string.Empty;
+
+            var mime = MimeTypeNames.FromExtension(extension);
+
+            return $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
         }
     }
 }

--- a/src/SmartReader/Image.cs
+++ b/src/SmartReader/Image.cs
@@ -2,8 +2,6 @@
 
 using System;
 
-using AngleSharp.Io;
-
 namespace SmartReader
 {
     /// <summary>
@@ -27,12 +25,7 @@ namespace SmartReader
         /// <param name="bytes">The actual binary content of the image</param>
         internal static string ConvertImageToDataUri(string path, byte[] bytes)
         {
-            int dotIndex = path.IndexOf('.');
-            string extension = dotIndex > 0 ? path.Substring(dotIndex) : string.Empty;
-
-            var mime = MimeTypeNames.FromExtension(extension);
-
-            return $"data:{mime};base64,{Convert.ToBase64String(bytes)}";
+            return $"data:{MimeMapping.MimeUtility.GetMimeMapping(path)};base64,{Convert.ToBase64String(bytes)}";
         }
     }
 }

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -17,13 +17,13 @@ namespace SmartReader
     /// </summary>
     internal static class Readability
     {
-        private static readonly Regex RE_Normalize = new Regex(@"\s{2,}", RegexOptions.IgnoreCase);
-        private static readonly Regex RE_SrcSetUrl = new Regex(@"(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))", RegexOptions.IgnoreCase);
+        private static readonly Regex RE_Normalize = new Regex(@"\s{2,}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex RE_SrcSetUrl = new Regex(@"(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         // See: https://schema.org/Article
         private static readonly Regex RE_JsonLdArticleTypes = new Regex(@"^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$");
         private static readonly Regex RE_Tokenize = new Regex(@"\W+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         // These are the list of HTML entities that need to be escaped.
-        private static Dictionary<string, string> htmlEscapeMap = new () {
+        private static readonly Dictionary<string, string> htmlEscapeMap = new () {
             { "lt", "<" },
             { "gt", ">" },
             { "amp", "&"},

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -32,6 +32,7 @@ namespace SmartReader
         };
 
         private static readonly char[] s_space = { ' ' };
+        private static readonly string[] s_img_picture_figure_video_audio_source = { "img", "picture", "figure", "video", "audio", "source" };
 
         /// <summary>
         /// Removes the class attribute from every element in the given
@@ -112,7 +113,7 @@ namespace SmartReader
                 }
             });
 
-            var medias = NodeUtility.GetAllNodesWithTag(articleContent, new string[] { "img", "picture", "figure", "video", "audio", "source" });
+            var medias = NodeUtility.GetAllNodesWithTag(articleContent, s_img_picture_figure_video_audio_source);
 
             NodeUtility.ForEachNode(medias, (mediaNode) => {
                 if (mediaNode is IElement media)

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Web;
 
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -30,15 +31,7 @@ namespace SmartReader
             "LiveBlogPosting", "DiscussionForumPosting", "TechArticle", "APIReference" 
         });
 
-        // These are the list of HTML entities that need to be escaped.
-        private static readonly Dictionary<string, string> htmlEscapeMap = new () {
-            { "lt", "<" },
-            { "gt", ">" },
-            { "amp", "&"},
-            { "quot", "\""},
-            { "apos", "'"}
-        };
-
+     
         private static readonly char[] s_space = { ' ' };
         private static readonly string[] s_img_picture_figure_video_audio_source = { "img", "picture", "figure", "video", "audio", "source" };
 
@@ -334,29 +327,6 @@ namespace SmartReader
             return false;
         }
 
-        /// <summary>
-        /// Converts some of the common HTML entities in string to their corresponding characters.
-        /// <para>This verifies that the input is a string, and that the length
-		/// is less than 100 chars.</para> 
-        /// </summary>
-        /// <param name="str">a string to unescape</param>
-        /// <returns>String without HTML entity</returns>
-        internal static string UnescapeHtmlEntities(string str)
-        {
-            if (String.IsNullOrEmpty(str))
-            {
-                return str;
-            }
-
-            return Regex.Replace(Regex.Replace(str, @"&(quot|amp|apos|lt|gt);", (tag) => {
-                return htmlEscapeMap[tag.Groups[1].Value];
-            }), @"&#(?:x([0-9a-z]{1,4})|([0-9]{1,4}));", (entity) =>
-            {
-                var num = Convert.ToUInt32(!string.IsNullOrEmpty(entity.Groups[1]?.Value) ? entity.Groups[1]?.Value : entity.Groups[2]?.Value, !string.IsNullOrEmpty(entity.Groups[1]?.Value) ? 16 : 10);
-                return Convert.ToChar(num).ToString();
-            });                   
-        }
-   
         /// <summary>
         /// Try to extract metadata from JSON-LD object.
         /// For now, only Schema.org objects of type Article or its subtypes are supported.
@@ -726,9 +696,9 @@ namespace SmartReader
 
             // in many sites the meta value is escaped with HTML entities,
             // so here we need to unescape it    
-            metadata.Title = UnescapeHtmlEntities(metadata.Title);            
-            metadata.Excerpt = UnescapeHtmlEntities(metadata.Excerpt);
-            metadata.SiteName = UnescapeHtmlEntities(metadata.SiteName);
+            metadata.Title = HttpUtility.HtmlDecode(metadata.Title).Trim();            
+            metadata.Excerpt = HttpUtility.HtmlDecode(metadata.Excerpt).Trim();
+            metadata.SiteName = HttpUtility.HtmlDecode(metadata.SiteName).Trim();
 
             return metadata;
         }

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -19,9 +19,16 @@ namespace SmartReader
     {
         private static readonly Regex RE_Normalize = new Regex(@"\s{2,}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RE_SrcSetUrl = new Regex(@"(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        // See: https://schema.org/Article
-        private static readonly Regex RE_JsonLdArticleTypes = new Regex(@"^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$");
         private static readonly Regex RE_Tokenize = new Regex(@"\W+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // See: https://schema.org/Article
+        private static readonly HashSet<string> JsonLdArticleTypes = new (new[] {
+            "Article", "AdvertiserContentArticle", "NewsArticle", "AnalysisNewsArticle", "AskPublicNewsArticle",
+            "BackgroundNewsArticle", "OpinionNewsArticle", "ReportageNewsArticle", "ReviewNewsArticle", "Report",
+            "SatiricalArticle", "ScholarlyArticle", "MedicalScholarlyArticle", "SocialMediaPosting", "BlogPosting",
+            "LiveBlogPosting", "DiscussionForumPosting", "TechArticle", "APIReference" 
+        });
+
         // These are the list of HTML entities that need to be escaped.
         private static readonly Dictionary<string, string> htmlEscapeMap = new () {
             { "lt", "<" },
@@ -383,7 +390,7 @@ namespace SmartReader
                         foreach (var obj in graph)
                         {
                             if (obj.TryGetProperty("@type", out value)
-                                && RE_JsonLdArticleTypes.IsMatch(value.GetString()))
+                                && JsonLdArticleTypes.Contains(value.GetString()!))
                             {
                                 root = obj;
                                 break;
@@ -398,7 +405,7 @@ namespace SmartReader
                     }
 
                     if (!root.TryGetProperty("@type", out value)
-                        || !RE_JsonLdArticleTypes.IsMatch(value.GetString()))
+                        || !JsonLdArticleTypes.Contains(value.GetString()!))
                     {
                         return jsonLDMetadata;
                     }

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -671,28 +671,28 @@ namespace SmartReader
             // added language extraction            
             IEnumerable<DateTime?> DateHeuristics()
             {
-                yield return values.ContainsKey("jsonld:datePublished")
-                    && DateTime.TryParse(values["jsonld:datePublished"], out date) ?
+                yield return values.TryGetValue("jsonld:datePublished", out var jsonLdDatePublished)
+                    && DateTime.TryParse(jsonLdDatePublished, out date) ?
                     date : DateTime.MinValue;
 
-                yield return values.ContainsKey("article:published_time")
-                    && DateTime.TryParse(values["article:published_time"], out date) ?
+                yield return values.TryGetValue("article:published_time", out var articlePublishedTime)
+                    && DateTime.TryParse(articlePublishedTime, out date) ?
                     date : DateTime.MinValue;
 
-                yield return values.ContainsKey("date")
-                    && DateTime.TryParse(values["date"], out date) ?
+                yield return values.TryGetValue("date", out var dateValue)
+                    && DateTime.TryParse(dateValue, out date) ?
                     date : DateTime.MinValue;
 
-                yield return values.ContainsKey("datepublished")
-                  && DateTime.TryParse(values["datepublished"], out date) ?
+                yield return values.TryGetValue("datepublished", out var datePublishedValue)
+                  && DateTime.TryParse(datePublishedValue, out date) ?
                   date : DateTime.MinValue;
 
-                yield return values.ContainsKey("weibo:article:create_at")
-                  && DateTime.TryParse(values["weibo:article:create_at"], out date) ?
+                yield return values.TryGetValue("weibo:article:create_at", out var weiboArticleCreateAt)
+                  && DateTime.TryParse(weiboArticleCreateAt, out date) ?
                   date : DateTime.MinValue;
 
-                yield return values.ContainsKey("weibo:webpage:create_at")
-                  && DateTime.TryParse(values["weibo:webpage:create_at"], out date) ?
+                yield return values.TryGetValue("weibo:webpage:create_at", out var weiboWebPageCreateAt)
+                  && DateTime.TryParse(weiboWebPageCreateAt, out date) ?
                   date : DateTime.MinValue;
             }
 

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -717,9 +718,9 @@ namespace SmartReader
                 Match maybeDate = Regex.Match(uri.PathAndQuery, "/(?<year>[0-9]{4})/(?<month>[0-9]{2})/(?<day>[0-9]{2})?");
                 if (maybeDate.Success)
                 {
-                    metadata.PublicationDate = new DateTime(int.Parse(maybeDate.Groups["year"].Value),
-                        int.Parse(maybeDate.Groups["month"].Value),
-                        !string.IsNullOrEmpty(maybeDate.Groups["day"].Value) ? int.Parse(maybeDate.Groups["day"].Value) : 1);
+                    metadata.PublicationDate = new DateTime(int.Parse(maybeDate.Groups["year"].Value, CultureInfo.InvariantCulture),
+                        int.Parse(maybeDate.Groups["month"].Value, CultureInfo.InvariantCulture),
+                        !string.IsNullOrEmpty(maybeDate.Groups["day"].Value) ? int.Parse(maybeDate.Groups["day"].Value, CultureInfo.InvariantCulture) : 1);
                 }
             }
 

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -114,11 +114,9 @@ namespace SmartReader
 
             var medias = NodeUtility.GetAllNodesWithTag(articleContent, new string[] { "img", "picture", "figure", "video", "audio", "source" });
 
-            NodeUtility.ForEachNode(medias, (media_node) => {
-                if (media_node is IElement)
+            NodeUtility.ForEachNode(medias, (mediaNode) => {
+                if (mediaNode is IElement media)
                 {
-                    var media = media_node as IElement;
-
                     if (media.GetAttribute("src") is string src)
                     {
                         media.SetAttribute("src", uri.ToAbsoluteURI(src));
@@ -164,7 +162,6 @@ namespace SmartReader
 
             return title;
         }
-
         /// <summary>
         /// Simplify nested elements
         /// </summary>
@@ -178,11 +175,11 @@ namespace SmartReader
 
             while (node != null)
             {
-                if (node.Parent != null && (new string[] { "DIV", "SECTION"}).Contains(node.TagName) && !(!String.IsNullOrWhiteSpace(node.Id) && node.Id.StartsWith("readability")))
+                if (node.Parent != null && node.TagName is "DIV" or "SECTION" && !(node.Id is string id && id.StartsWith("readability", StringComparison.Ordinal)))
                 {
                     if (NodeUtility.IsElementWithoutContent(node))
                     {
-                        node = NodeUtility.RemoveAndGetNext(node) as IElement;
+                        node = NodeUtility.RemoveAndGetNext(node);
                         continue;
                     }
                     else if (NodeUtility.HasSingleTagInsideElement(node, "DIV") || NodeUtility.HasSingleTagInsideElement(node, "SECTION"))
@@ -408,18 +405,18 @@ namespace SmartReader
                     if (root.TryGetProperty("name", out value)
                         && value.ValueKind == JsonValueKind.String)
                     {
-                        jsonLDMetadata["jsonld:title"] = value.GetString().Trim();
+                        jsonLDMetadata["jsonld:title"] = value.GetString()!.Trim();
                     }
                     if (root.TryGetProperty("headline", out value)
                         && value.ValueKind == JsonValueKind.String)
                     {
-                        jsonLDMetadata["jsonld:title"] = value.GetString().Trim();
+                        jsonLDMetadata["jsonld:title"] = value.GetString()!.Trim();
                     }
                     if (root.TryGetProperty("author", out value))
                     {
                         if (value.ValueKind == JsonValueKind.Object)
                         {
-                            jsonLDMetadata["jsonld:author"] = value.GetProperty("name").GetString().Trim();
+                            jsonLDMetadata["jsonld:author"] = value.GetProperty("name").GetString()!.Trim();
                         }
                         else if (value.ValueKind == JsonValueKind.Array
                             && value.EnumerateArray().ElementAt(0).GetProperty("name").ValueKind == JsonValueKind.String)
@@ -430,7 +427,7 @@ namespace SmartReader
                             {
                                 if (author.TryGetProperty("name", out value)
                                 && value.ValueKind == JsonValueKind.String)
-                                    byline.Add(value.GetString().Trim());
+                                    byline.Add(value.GetString()!.Trim());
                             }
 
                             jsonLDMetadata["jsonld:author"] = String.Join(", ", byline);
@@ -440,22 +437,22 @@ namespace SmartReader
                     if (root.TryGetProperty("description", out value)
                         && value.ValueKind == JsonValueKind.String)
                     {
-                        jsonLDMetadata["jsonld:description"] = value.GetString().Trim();
+                        jsonLDMetadata["jsonld:description"] = value.GetString()!.Trim();
                     }
                     if (root.TryGetProperty("publisher", out value)
                         && value.ValueKind == JsonValueKind.Object)
                     {
-                        jsonLDMetadata["jsonld:siteName"] = value.GetProperty("name").GetString().Trim();
+                        jsonLDMetadata["jsonld:siteName"] = value.GetProperty("name").GetString()!.Trim();
                     }
                     if (root.TryGetProperty("datePublished", out value)
                         && value.ValueKind == JsonValueKind.String)
                     {
-                        jsonLDMetadata["jsonld:datePublished"] = value.GetProperty("datePublished").GetString();
+                        jsonLDMetadata["jsonld:datePublished"] = value.GetProperty("datePublished").GetString()!;
                     }
                     if (root.TryGetProperty("image", out value)
                         && value.ValueKind == JsonValueKind.String)
                     {
-                        jsonLDMetadata["jsonld:image"] = value.GetProperty("image").GetString();
+                        jsonLDMetadata["jsonld:image"] = value.GetProperty("image").GetString()!;
                     }
                 }
                 catch(Exception e)
@@ -476,7 +473,7 @@ namespace SmartReader
         /// <param name="language">The language that was possibly found in the headers of the response</param>
         /// <param name="jsonLD">The dictionary containing metadata found in JSON LD</param>
         /// <returns>The metadata object with all the info found</returns>
-        internal static Metadata GetArticleMetadata(IHtmlDocument doc, Uri uri, string language, Dictionary<string, string> jsonLD)
+        internal static Metadata GetArticleMetadata(IHtmlDocument doc, Uri uri, string? language, Dictionary<string, string> jsonLD)
         {
             var metadata = new Metadata();
             Dictionary<string, string> values = jsonLD;            

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -140,7 +140,9 @@ namespace SmartReader
                     }
                 }            
             });
-        }               
+        }
+
+        private static readonly char[] titleSeperators = { '|', '-', '»', '/', '>' };
 
         /// <summary>
         /// Clean the article title found in a tag
@@ -150,10 +152,10 @@ namespace SmartReader
         /// <returns>
         /// The clean title
         /// </returns>
-        internal static string CleanTitle(string title, string siteName)
+        internal static string CleanTitle(string title, string? siteName)
         {
             // eliminate any text after a separator
-            if (!string.IsNullOrEmpty(siteName) && title.IndexOfAny(new char[] { '|', '-', '»', '/', '>' }) != -1)
+            if (!string.IsNullOrEmpty(siteName) && title.IndexOfAny(titleSeperators) != -1)
             {
 
                 // we eliminate the text after the separator only if it is the site name

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -305,8 +305,8 @@ namespace SmartReader
         /// <param name="textb">second text to compare</param>
         internal static int TextSimilarity(string textA, string textB)
         {
-            var tokensA = RE_Tokenize.Split(textA.ToLower()).Where(x => !string.IsNullOrEmpty(x)).ToArray();
-            var tokensB = RE_Tokenize.Split(textB.ToLower()).Where(x => !string.IsNullOrEmpty(x)).ToArray();
+            var tokensA = RE_Tokenize.Split(textA.ToLowerInvariant()).Where(x => !string.IsNullOrEmpty(x)).ToArray();
+            var tokensB = RE_Tokenize.Split(textB.ToLowerInvariant()).Where(x => !string.IsNullOrEmpty(x)).ToArray();
             if (tokensA is not { Length: > 0 } || tokensB is not { Length: > 0 })
             {
                 return 0;
@@ -528,7 +528,7 @@ namespace SmartReader
                     {                        
                         // Convert to lowercase, and remove any whitespace
                         // so we can match below.
-                        name = Regex.Replace(matches[0].Value.ToLower(), @"\s+", "");
+                        name = Regex.Replace(matches[0].Value.ToLowerInvariant(), @"\s+", "");
 
                         // multiple authors
                         values[name] = content.Trim();                        
@@ -542,7 +542,7 @@ namespace SmartReader
                     
                     // Convert to lowercase, remove any whitespace, and convert dots
                     // to colons so we can match below.
-                    name = Regex.Replace(Regex.Replace(name.ToLower(), @"\s+", ""), @"\.", ":");
+                    name = Regex.Replace(Regex.Replace(name.ToLowerInvariant(), @"\s+", ""), @"\.", ":");
                     values[name] = content.Trim();
                 }
                 else if (elementProperty is { Length: > 0 } && Regex.IsMatch(elementProperty, propertyPattern, RegexOptions.IgnoreCase))
@@ -561,7 +561,7 @@ namespace SmartReader
                     {
                         // Convert to lowercase and remove any whitespace
                         // so we can match below.
-                        name = Regex.Replace(name.ToLower(), @"\s", "", RegexOptions.IgnoreCase);
+                        name = Regex.Replace(name.ToLowerInvariant(), @"\s", "", RegexOptions.IgnoreCase);
                         if (!values.ContainsKey(name))
                             values.Add(name, content.Trim());
                     }

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -1400,14 +1400,13 @@ namespace SmartReader
         /// <param name="filterFn">Filter to ignore some matching tags</param>
         private bool HasAncestorTag(IElement node, string tagName, int maxDepth = 3, Func<IElement, bool>? filterFn = null)
         {
-            tagName = tagName.ToUpper();
             var depth = 0;
 
             while (node.ParentElement != null)
             {
                 if (maxDepth > 0 && depth > maxDepth)
                     return false;
-                if (node.ParentElement.TagName == tagName
+                if (string.Equals(node.ParentElement.TagName, tagName, StringComparison.OrdinalIgnoreCase)
                     && (filterFn is null || filterFn(node.ParentElement)))
                     return true;
                 node = node.ParentElement;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -110,7 +110,7 @@ namespace SmartReader
         /// <value>Default: 500</value>
         public int CharThreshold { get; set; } = 500;
         
-        private string[] classesToPreserve = { "page" };        
+        private string[] classesToPreserve = { "page" };
         /// <summary>
         /// The classes that must be preserved
         /// </summary>
@@ -1982,7 +1982,7 @@ namespace SmartReader
 
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
 
-            HttpRequestMessage headRequest = new HttpRequestMessage(HttpMethod.Head, imageSrc);
+            var headRequest = new HttpRequestMessage(HttpMethod.Head, imageSrc);
             var response = await httpClient.SendAsync(headRequest).ConfigureAwait(false);
 
             long size = 0;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -109,8 +109,11 @@ namespace SmartReader
         /// </summary>
         /// <value>Default: 500</value>
         public int CharThreshold { get; set; } = 500;
-        
+
+        private static readonly IEnumerable<string> s_page = new string[] { "page" };
+
         private string[] classesToPreserve = { "page" };
+
         /// <summary>
         /// The classes that must be preserved
         /// </summary>
@@ -125,7 +128,7 @@ namespace SmartReader
             {
                 classesToPreserve = value;
 
-                classesToPreserve = classesToPreserve.Union(new string[] { "page" }).ToArray();
+                classesToPreserve = classesToPreserve.Union(s_page).ToArray();
             }
         }
 
@@ -218,6 +221,7 @@ namespace SmartReader
         private static readonly string[] s_ul_ol = { "ul", "ol" };
         private static readonly string[] s_h1_h2 = { "h1", "h2" };
         private static readonly string[] s_h1_h2_h3_h4_h5_h6 = { "h1", "h2", "h3", "h4", "h5", "h6" };
+        private static readonly string[] s_IMG_PICTURE = { "IMG", "PICTURE" };
 
         /// <summary>
         /// Reads content from the given URI.
@@ -1455,6 +1459,9 @@ namespace SmartReader
             return Tuple.Create(rows, columns);
         }
 
+
+        private static readonly string[] dataTableDescendantTagNames = { "col", "colgroup", "tfoot", "thead", "th" };
+
         /// <summary>
         /// Look for 'data' (as opposed to 'layout') tables, for which we use
         /// similar checks as
@@ -1492,13 +1499,13 @@ namespace SmartReader
                     continue;
                 }
 
-                // If the table has a descendant with any of these tags, consider a data table:
-                var dataTableDescendants = new string[] { "col", "colgroup", "tfoot", "thead", "th" };
+                // If the table has a descendant with a COL, COLGROUP, TFOOT, THEAD, or TH tag, consider a data table:
                 bool descendantExists(string tag)
                 {
                     return table.GetElementsByTagName(tag).ElementAtOrDefault(0) != null;
                 }
-                if (dataTableDescendants.Any(descendantExists))
+
+                if (dataTableDescendantTagNames.Any(descendantExists))
                 {
                     if (Debug || Logging == ReportLevel.Info)
                         LoggerDelegate("Data table because found data-y descendant");
@@ -1611,7 +1618,7 @@ namespace SmartReader
                             elem.SetAttribute(copyTo, attr.Value);
                         }
                         else if (elem.TagName is "FIGURE"
-                        && NodeUtility.GetAllNodesWithTag(elem, new string[] { "IMG", "PICTURE" }).Length == 0)
+                        && NodeUtility.GetAllNodesWithTag(elem, s_IMG_PICTURE).Length == 0)
                         {
                             //if the item is a <figure> that does not contain an image or picture, create one and place it inside the figure
                             //see the nytimes-3 testcase for an example

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -765,7 +765,7 @@ namespace SmartReader
 
                 articleByline = node.TextContent.Trim();
                 // we remove residual mustache (or similar templating) references
-                articleByline = Regex.Replace(articleByline.StartsWith("by") ? articleByline.Substring(2) : articleByline, @"{{.*?}}", "").Trim();
+                articleByline = Regex.Replace(articleByline.StartsWith("by", StringComparison.Ordinal) ? articleByline.Substring(2) : articleByline, @"{{.*?}}", "").Trim();
                 return true;
             }
 
@@ -1849,7 +1849,7 @@ namespace SmartReader
                     return false;
                 }
 
-                var textContentLength = node.TextContent.Trim().Length;
+                var textContentLength = node.TextContent.AsSpan().Trim().Length;
                 if (textContentLength < MinContentLengthReadearable)
                 {
                     return false;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -746,9 +746,9 @@ namespace SmartReader
             string rel = "";
             string itemprop = "";
 
-            if (node is IElement && !string.IsNullOrEmpty(node.GetAttribute("rel")))
+            if (node is IElement && node.GetAttribute("rel") is { Length: > 0 } relValue)
             {
-                rel = node.GetAttribute("rel");
+                rel = relValue;
                 itemprop = node.GetAttribute("itemprop");
             }
 
@@ -1302,10 +1302,10 @@ namespace SmartReader
                     {
                         if (string.IsNullOrEmpty(ancestor.TagName))
                             return false;
-                        var _articleDir = ancestor.GetAttribute("dir");
-                        if (!string.IsNullOrEmpty(_articleDir))
+
+                        if (ancestor.GetAttribute("dir") is { Length: > 0 } dir)
                         {
-                            this.articleDir = _articleDir;
+                            this.articleDir = dir;
                             return true;
                         }
                         return false;
@@ -1466,20 +1466,20 @@ namespace SmartReader
             for (var i = 0; i < tables.Length; i++)
             {
                 var table = tables[i];
-                var role = table.GetAttribute("role");
-                if (role is "presentation")
+
+                if (table.GetAttribute("role") is "presentation")
                 {                    
                     table.SetAttribute("dataTable", "false");
                     continue;
                 }
-                var datatable = table.GetAttribute("datatable");
-                if (datatable is "0")
+
+                if (table.GetAttribute("datatable") is "0")
                 {                   
                     table.SetAttribute("dataTable", "false");
                     continue;
                 }
-                var summary = table.GetAttribute("summary");
-                if (!string.IsNullOrEmpty(summary))
+
+                if (table.GetAttribute("summary") is { Length: > 0 })
                 {
                     table.SetAttribute("dataTable", "true");                    
                     continue;

--- a/src/SmartReader/SmartReader.csproj
+++ b/src/SmartReader/SmartReader.csproj
@@ -7,6 +7,7 @@
     <VersionPrefix>0.1.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
     <AssemblyName>SmartReader</AssemblyName>
     <PackageId>SmartReader</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/SmartReader/SmartReader.csproj
+++ b/src/SmartReader/SmartReader.csproj
@@ -44,7 +44,6 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.15.0" />
     <PackageReference Include="AngleSharp.Css" Version="0.15.0" />
-    <PackageReference Include="MimeMapping" Version="1.0.1.37" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/SmartReader/SmartReader.csproj
+++ b/src/SmartReader/SmartReader.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.15.0" />
     <PackageReference Include="AngleSharp.Css" Version="0.15.0" />
+    <PackageReference Include="MimeMapping" Version="1.0.1.37" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/SmartReader/UriExtensions.cs
+++ b/src/SmartReader/UriExtensions.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace SmartReader
 {
-   internal static class UriExtensions
+    internal static class UriExtensions
     {
         internal static string GetBase(this Uri startUri)
         {
-            StringBuilder sb = new StringBuilder(startUri.Scheme + "://");
+            var sb = new StringBuilder(startUri.Scheme + "://");
 
             if (!string.IsNullOrEmpty(startUri.UserInfo))
                 sb.Append(startUri.UserInfo + "@");

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -319,7 +319,7 @@ namespace SmartReader
                             if (attr.Name is "src" or "srcset"
                             || Regex.IsMatch(attr.Value, @"\.(jpg|jpeg|png|webp)"))
                             {
-                                if (newImg.GetAttribute(attr.Name) == attr.Value)
+                                if (string.Equals(newImg.GetAttribute(attr.Name), attr.Value, StringComparison.Ordinal))
                                 {
                                     continue;
                                 }

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -244,7 +244,7 @@ namespace SmartReader
         internal static bool IsSingleImage(IElement element)
         {
             if (element.TagName is "IMG") return true;
-            if (element.Children.Length != 1 || element.TextContent.Trim() is not "") return false;
+            if (element.Children.Length != 1 || element.TextContent.AsSpan().Trim().Length != 0) return false;
             return IsSingleImage(element.Children[0]);
         }
 

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -21,8 +21,7 @@ namespace SmartReader
         private static readonly Regex RE_PrevLink     = new Regex(@"(prev|earl|old|new|<|«)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RE_Whitespace   = new Regex(@"^\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RE_HasContent   = new Regex(@"\S$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex RE_HashUrl = new Regex(@"^#.+", RegexOptions.IgnoreCase | RegexOptions.Compiled);              
-        
+        private static readonly Regex RE_HashUrl      = new Regex(@"^#.+", RegexOptions.IgnoreCase | RegexOptions.Compiled);              
 
         private static readonly string[] divToPElems = { "BLOCKQUOTE", "DL", "DIV", "IMG", "OL", "P", "PRE", "TABLE", "UL" };
         

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -83,7 +83,7 @@ namespace SmartReader
         internal static bool IsProbablyVisible(IElement node)
         {
             // Have to null-check node.style and node.className.indexOf to deal with SVG and MathML nodes.
-            return (node.GetStyle() is null || node?.GetStyle()?.GetDisplay() is not "none")
+            return (node.GetStyle() is null || node.GetStyle().GetDisplay() is not "none")
                 && !node.HasAttribute("hidden")
                 // check for "fallback-image" so that wikimedia math images are displayed
                 && (!node.HasAttribute("aria-hidden") || node.GetAttribute("aria-hidden") is not "true" || (node?.ClassName != null && node.ClassName.IndexOf("fallback-image") != -1));
@@ -97,7 +97,7 @@ namespace SmartReader
         /// </summary>
         /// <param name="nodeList">The nodes to operate on</param>
         /// <param name="filterFn">The filter that dictates which nodes to remove</param>
-        internal static void RemoveNodes(IEnumerable<IElement> nodeList, Func<IElement, bool> filterFn = null)
+        internal static void RemoveNodes(IEnumerable<IElement> nodeList, Func<IElement, bool>? filterFn = null)
         {
             for (var i = nodeList.Count() - 1; i >= 0; i--)
             {
@@ -165,7 +165,7 @@ namespace SmartReader
         /// <param name="nodeList">The nodes to operate on</param>
         /// <param name="fn">The iterate function</param>
         /// <returns>bool</returns>
-        internal static bool SomeNode(INodeList nodeList, Func<INode, bool> fn)
+        internal static bool SomeNode(INodeList? nodeList, Func<INode, bool> fn)
         {
             if (nodeList != null)
                 return nodeList.Any(fn);
@@ -181,7 +181,7 @@ namespace SmartReader
         /// <param name="elementList">The nodes to operate on</param>
         /// <param name="fn">The test function</param>
         /// <returns>INode</returns>
-        internal static IElement FindNode(IHtmlCollection<IElement> elementList, Func<IElement, bool> fn)
+        internal static IElement? FindNode(IHtmlCollection<IElement> elementList, Func<IElement, bool> fn)
         {
             foreach (var node in elementList)
             {
@@ -362,12 +362,12 @@ namespace SmartReader
         /// or if it contains no element with given tag or more than 1 element.
         /// </summary>
         /// <param name="element">Element to operate on</param>
-        /// <param name="tag">Tag of the child element</param>
+        /// <param name="tagName">Tag of the child element</param>
         /// <returns>bool</returns>
-        internal static bool HasSingleTagInsideElement(IElement element, string tag)
+        internal static bool HasSingleTagInsideElement(IElement element, string tagName)
         {
             // There should be exactly 1 element child with given tag:
-            if (element.Children.Length != 1 || element.Children[0].TagName != tag)
+            if (element.Children.Length != 1 || !string.Equals(element.Children[0].TagName, tagName, StringComparison.Ordinal))
             {
                 return false;
             }
@@ -393,13 +393,15 @@ namespace SmartReader
         /// </summary>
         /// <param name="element">Element to operate on</param>
         /// <returns>bool</returns>
-        internal static bool HasChildBlockElement(IElement element)
+        internal static bool HasChildBlockElement(IElement? element)
         {
             var b = SomeNode(element?.ChildNodes, (node) =>
             {
-                return divToPElems.Contains((node as IElement)?.TagName)
-                    || HasChildBlockElement(node as IElement);
+                var el = node as IElement;
+
+                return el is not null && (divToPElems.Contains(el.TagName) || HasChildBlockElement(el));
             });
+
             var d = element?.TextContent;
 
             return b;
@@ -427,18 +429,16 @@ namespace SmartReader
         /// <para>Get the inner text of a node - cross browser compatibly.</para>
         /// <para>This also strips out any excess whitespace to be found.</para>
         /// </summary>
-        /// <param name="e">Node to operate on</param>
+        /// <param name="node">Node to operate on</param>
         /// <param name="normalizeSpaces">Bool to set whether to normalize whitespace</param>
         /// <returns>String with the text of the node</returns>
-        internal static string GetInnerText(INode e, bool normalizeSpaces = true)
+        internal static string GetInnerText(INode node, bool normalizeSpaces = true)
         {
-            var textContent = e.TextContent.Trim();
+            var textContent = node.TextContent.Trim();
 
-            if (normalizeSpaces)
-            {
-                return RE_Normalize.Replace(textContent, " ");
-            }
-            return textContent;
+            return (normalizeSpaces)
+                ? RE_Normalize.Replace(textContent, " ")
+                : textContent;
         }
 
         /// <summary>
@@ -456,25 +456,25 @@ namespace SmartReader
         /// <para>Remove the style attribute on every e and under.</para>
         /// <para>TODO: Test if getElementsByTagName(*) is faster.</para>
         /// </summary>
-        /// <param name="e">Element to operate on</param>
-        internal static void CleanStyles(IElement e = null)
+        /// <param name="el">Element to operate on</param>
+        internal static void CleanStyles(IElement? el = null)
         {            
-            if (e is null || e.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase))
+            if (el is null || el.TagName.Equals("svg", StringComparison.OrdinalIgnoreCase))
                 return;
 
             // Remove `style` and deprecated presentational attributes
             for (var i = 0; i < presentationalAttributes.Length; i++)
             {
-                e.RemoveAttribute(presentationalAttributes[i]);
+                el.RemoveAttribute(presentationalAttributes[i]);
             }
 
-            if (deprecatedSizeAttributeElems.FirstOrDefault(x => x.Equals(e.TagName, StringComparison.Ordinal)) != null)
+            if (deprecatedSizeAttributeElems.Contains(el.TagName))
             {
-                e.RemoveAttribute("width");
-                e.RemoveAttribute("height");
+                el.RemoveAttribute("width");
+                el.RemoveAttribute("height");
             }
 
-            var cur = e.FirstElementChild;
+            var cur = el.FirstElementChild;
             while (cur != null)
             {
                 CleanStyles(cur);
@@ -498,19 +498,21 @@ namespace SmartReader
 
             // XXX implement _reduceNodeList?
             ForEachNode(element.GetElementsByTagName("a"), (linkNode) =>
-            {                
-                var href = (linkNode as IElement).GetAttribute("href");
+            {
+                var linkEl = ((IElement)linkNode);
+
+                var href = linkEl.GetAttribute("href");
                 var coefficient = href is { Length: > 0 } && RE_HashUrl.IsMatch(href) ? 0.3 : 1; 
-                linkLength += GetInnerText(linkNode as IElement).Length * coefficient;
+                linkLength += GetInnerText(linkEl).Length * coefficient;
             });
 
             return linkLength / textLength;
         }
 
-        internal static INode RemoveAndGetNext(INode node)
+        internal static IElement? RemoveAndGetNext(IElement element)
         {
-            var nextNode = GetNextNode(node as IElement, true);
-            node.Parent.RemoveChild(node);
+            var nextNode = GetNextNode(element, true);
+            element.Parent.RemoveChild(element);
             return nextNode;
         }
 
@@ -523,7 +525,7 @@ namespace SmartReader
         /// <param name="node">Node to operate on</param>  
         /// <param name="ignoreSelfAndKids">Whether to ignore this node and his kids</param>  
         /// <returns>The next node</returns>
-        internal static IElement GetNextNode(IElement node, bool ignoreSelfAndKids = false)
+        internal static IElement? GetNextNode(IElement node, bool ignoreSelfAndKids = false)
         {
             // First check for kids if those aren't being ignored
             if (!ignoreSelfAndKids && node.FirstElementChild != null)
@@ -551,7 +553,7 @@ namespace SmartReader
         /// </summary>
         /// <param name="e">Element to operate on</param>  
         /// <param name="filter">Filter function on match id/class combination</param> 
-        internal static void CleanMatchedNodes(IElement e, Func<IElement, string, bool> filter = null)
+        internal static void CleanMatchedNodes(IElement e, Func<IElement, string, bool> filter)
         {
             var endOfSearchMarkerNode = GetNextNode(e, true);
             var next = GetNextNode(e);
@@ -559,7 +561,7 @@ namespace SmartReader
             {
                 if (filter(next, next.ClassName + " " + next.Id))
                 {
-                    next = RemoveAndGetNext(next) as IElement;
+                    next = RemoveAndGetNext(next);
                 }
                 else
                 {
@@ -643,7 +645,7 @@ namespace SmartReader
         /// whitespace in between. If the given node is an element, the same node is
         /// returned.
         /// </summary>  
-        internal static IElement NextElement(INode node, Regex whitespace)
+        internal static IElement? NextElement(INode node, Regex whitespace)
         {
             var next = node;
             while (next != null

--- a/src/SmartReaderTests/test-pages/msn/expected-metadata.json
+++ b/src/SmartReaderTests/test-pages/msn/expected-metadata.json
@@ -2,7 +2,7 @@
   "title": "Nintendo's first iPhone game will launch in December for $10",
   "byline": "Alex Perry\n                        \n                        1 day ago",
   "dir": "ltr",
-  "excerpt": "Nintendo and Apple shocked the world earlier this year by announcing \"Super Mario Run,\" the legendary gaming company's first foray into mobile gaming.&nbsp;",
+  "excerpt": "Nintendo and Apple shocked the world earlier this year by announcing \"Super Mario Run,\" the legendary gaming company's first foray into mobile gaming.",
   "readerable": true,
   "language": "en-US",
   "timeToRead": "00:01:00",


### PR DESCRIPTION
- Enables nullable
- Eliminates lots of allocations
- Replaces a regex with a HashSet (10x faster)
- Update various parsing and formatting methods to use an invariant culture
- Reduce lookups (for dictionaries and attributes)
- Replace custom html entity decoding logic with HttpUtility.HtmlDecode
- Use built in mime map from AngleSharp

The test library runs around 11% faster for me after these changes.