### PR TITLE
Resolve a NU1608 warning in the SmartReader.WebDemo.csproj

### DIFF
--- a/src/SmartReader.WebDemo/SmartReader.WebDemo.csproj
+++ b/src/SmartReader.WebDemo/SmartReader.WebDemo.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.0" />
     <PackageReference Include="AngleSharp.Css" Version="0.16.0" />
-    <PackageReference Include="HtmlSanitizer" Version="5.0.404" />
+    <PackageReference Include="HtmlSanitizer" Version="6.0.430-beta" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the SmartReader.WebDemo.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: HtmlSanitizer 5.0.404 requires AngleSharp (= 0.15.0) but version AngleSharp 0.16.0.`
`Warning NU1608 Detected package version outside of dependency constraint: HtmlSanitizer 5.0.404 requires AngleSharp.Css (= 0.15.0) but version AngleSharp.Css 0.16.0.`

This fix can remove this warnings from SmartReader's dependency graph.
Hope the PR can help you.

Best regards,
sucrose