### PR TITLE
Reduce allocations & update alternativeCandidateAncestors to match readability.js

### DIFF
--- a/src/SmartReader/Article.cs
+++ b/src/SmartReader/Article.cs
@@ -128,7 +128,7 @@ namespace SmartReader
         /// </returns>  
         public async Task<IReadOnlyList<Image>> GetImagesAsync(long minSize = 75_000)
         {
-            var imgs = _element?.QuerySelectorAll("img");
+            var imgs = _element?.GetElementsByTagName("img");
 
             if (imgs is null)
             {
@@ -188,7 +188,7 @@ namespace SmartReader
         {
             if (_element is null) return;
 
-            foreach (var img in _element.QuerySelectorAll("img"))
+            foreach (var img in _element.GetElementsByTagName("img"))
             {
                 if (img.GetAttribute("src") is string src)
                 {

--- a/src/SmartReader/Article.cs
+++ b/src/SmartReader/Article.cs
@@ -55,7 +55,7 @@ namespace SmartReader
 
         /// <summary>The function that will serialize the HTML content of the article</summary>
         /// <value>Default: return InnerHTML property</value>       
-        public static Func<IElement, string> Serializer { get; set; } = new Func<IElement, string>((el) => { return el.InnerHtml; });
+        public static Func<IElement, string> Serializer { get; set; } = new Func<IElement, string>(el => el.InnerHtml);
 
         /// <summary>The function that will extract the text from the HTML content</summary>
         /// <value>Default: return InnerHTML property</value>       

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -75,7 +75,7 @@ namespace SmartReader
             var prePath = uri.GetBase();
             var pathBase = uri.Scheme + "://" + uri.Host + uri.AbsolutePath.Substring(0, uri.AbsolutePath.LastIndexOf('/') + 1);
 
-            var links = articleContent.QuerySelectorAll("a");
+            var links = articleContent.GetElementsByTagName("a");
 
             NodeUtility.ForEachElement(links, link =>
             {
@@ -323,7 +323,7 @@ namespace SmartReader
         {
             var jsonLDMetadata = new Dictionary<string, string>();
             
-            var scripts = doc.DocumentElement.QuerySelectorAll("script");
+            var scripts = doc.DocumentElement.GetElementsByTagName("script");
 
             var jsonLdElement = scripts.FirstOrDefault(el => {
                 return el?.GetAttribute("type") is "application/ld+json";

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -75,16 +75,16 @@ namespace SmartReader
             var prePath = uri.GetBase();
             var pathBase = uri.Scheme + "://" + uri.Host + uri.AbsolutePath.Substring(0, uri.AbsolutePath.LastIndexOf('/') + 1);
 
-            var links = NodeUtility.GetAllNodesWithTag(articleContent, "a");
+            var links = articleContent.QuerySelectorAll("a");
 
-            NodeUtility.ForEachElement(links, (link) =>
+            NodeUtility.ForEachElement(links, link =>
             {
-                var href = link.GetAttribute("href");
+                var href = link.GetAttribute("href")!;
                 if (!string.IsNullOrWhiteSpace(href))
                 {
                     // Remove links with javascript: URIs, since
                     // they won't work after scripts have been removed from the page.
-                    if (href!.IndexOf("javascript:") == 0)
+                    if (href.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase))
                     {
                         // if the link only contains simple text content, it can be converted to a text node
                         if (link.ChildNodes.Length == 1 && link.ChildNodes[0].NodeType == NodeType.Text)
@@ -323,7 +323,7 @@ namespace SmartReader
         {
             var jsonLDMetadata = new Dictionary<string, string>();
             
-            var scripts = NodeUtility.GetAllNodesWithTag(doc.DocumentElement, "script");
+            var scripts = doc.DocumentElement.QuerySelectorAll("script");
 
             var jsonLdElement = scripts.FirstOrDefault(el => {
                 return el?.GetAttribute("type") is "application/ld+json";

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -310,7 +310,7 @@ namespace SmartReader
         /// <returns>Whether the input string is a byline</returns>
         internal static bool IsValidByline(ReadOnlySpan<char> byline)
         {
-            return byline.Trim().Length is > 0 and < 100;            
+            return byline.Trim().Length is > 0 and < 100;
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace SmartReader
             
             var scripts = NodeUtility.GetAllNodesWithTag(doc.DocumentElement, "script");
 
-            var jsonLdElement = NodeUtility.FindNode(scripts, (el) => {
+            var jsonLdElement = scripts.FirstOrDefault(el => {
                 return el?.GetAttribute("type") is "application/ld+json";
             });
 

--- a/src/SmartReader/Readability.cs
+++ b/src/SmartReader/Readability.cs
@@ -77,8 +77,10 @@ namespace SmartReader
 
             var links = articleContent.GetElementsByTagName("a");
 
-            NodeUtility.ForEachElement(links, link =>
+            for (int i = 0; i < links.Length; i++)
             {
+                var link = links[i];
+
                 var href = link.GetAttribute("href")!;
                 if (!string.IsNullOrWhiteSpace(href))
                 {
@@ -108,7 +110,7 @@ namespace SmartReader
                         link.SetAttribute("href", uri.ToAbsoluteURI(href));
                     }
                 }
-            });
+            }
 
             var medias = NodeUtility.GetAllNodesWithTag(articleContent, s_img_picture_figure_video_audio_source);
 
@@ -325,7 +327,7 @@ namespace SmartReader
             
             var scripts = doc.DocumentElement.GetElementsByTagName("script");
 
-            var jsonLdElement = scripts.FirstOrDefault(el => {
+            var jsonLdElement = scripts.FirstOrDefault(static el => {
                 return el?.GetAttribute("type") is "application/ld+json";
             });
 
@@ -447,16 +449,16 @@ namespace SmartReader
             // Match "description", or Twitter's "twitter:description" (Cards)
             // in name attribute.
             // name is a single value
-            var namePattern = @"^\s*((?:(dc|dcterm|og|twitter|weibo:(article|webpage))\s*[\.:]\s*)?(author|creator|description|title|image|site_name)|name)\s*$";
+            const string namePattern = @"^\s*((?:(dc|dcterm|og|twitter|weibo:(article|webpage))\s*[\.:]\s*)?(author|creator|description|title|image|site_name)|name)\s*$";
 
             // Match Facebook's Open Graph title & description properties.
             // property is a space-separated list of values
-            var propertyPattern = @"\s*(dc|dcterm|og|twitter|article)\s*:\s*(author|creator|description|title|published_time|image|site_name)(\s+|$)";
+            const string propertyPattern = @"\s*(dc|dcterm|og|twitter|article)\s*:\s*(author|creator|description|title|published_time|image|site_name)(\s+|$)";
 
-            var itemPropPattern = @"\s*datePublished\s*";
+            const string itemPropPattern = @"\s*datePublished\s*";
 
             // Find description tags.
-            NodeUtility.ForEachElement(metaElements, (element) =>
+            foreach (var element in metaElements)
             {
                 var elementName = element.GetAttribute("name");
                 var elementProperty = element.GetAttribute("property");
@@ -466,7 +468,7 @@ namespace SmartReader
                 // avoid issues with no meta tags
                 if (content is null || content.Length == 0)
                 {
-                    return;
+                    continue;
                 }
                 MatchCollection? matches = null;
                 string name = "";
@@ -521,7 +523,7 @@ namespace SmartReader
                             values.Add(name, content.Trim());
                     }
                 }
-            });
+            }
 
             // Find the the description of the article
             IEnumerable<string?> DescriptionKeys()

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -1015,13 +1015,12 @@ namespace SmartReader
                     // Find a better top candidate node if it contains (at least three) nodes which belong to `topCandidates` array
                     // and whose scores are quite closed with current `topCandidate` node.
   
-                    var alternativeCandidateAncestors = new List<IElement>();
+                    var alternativeCandidateAncestors = new List<IList<INode>>();
                     for (var i = 1; i < topCandidates.Count; i++)
                     {                        
                         if (GetReadabilityScore(topCandidates[i]) / GetReadabilityScore(topCandidate) >= 0.75)
                         {
-                            if (NodeUtility.GetNodeAncestors(topCandidates[i]) is IElement possibleAncestor)
-                                alternativeCandidateAncestors.Add(possibleAncestor);
+                            alternativeCandidateAncestors.Add(NodeUtility.GetNodeAncestors(topCandidates[i]));
                         }
                     }
                     const int MINIMUM_TOPCANDIDATES = 3;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -1015,7 +1015,7 @@ namespace SmartReader
                     // Find a better top candidate node if it contains (at least three) nodes which belong to `topCandidates` array
                     // and whose scores are quite closed with current `topCandidate` node.
   
-                    var alternativeCandidateAncestors = new List<IList<INode>>();
+                    var alternativeCandidateAncestors = new List<List<INode>>();
                     for (var i = 1; i < topCandidates.Count; i++)
                     {                        
                         if (GetReadabilityScore(topCandidates[i]) / GetReadabilityScore(topCandidate) >= 0.75)

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -455,7 +455,7 @@ namespace SmartReader
         /// </summary>
         private void ReplaceBrs(IElement elem)
         {
-            NodeUtility.ForEachElement(NodeUtility.GetAllNodesWithTag(elem, "br"), (br) =>
+            NodeUtility.ForEachElement(elem.QuerySelectorAll("br"), br =>
             {
                 var next = br.NextSibling;
 
@@ -576,7 +576,7 @@ namespace SmartReader
             CleanConditionally(articleContent, "div");
 
             // replace H1 with H2 as H1 should be only title that is displayed separately
-            NodeUtility.ReplaceNodeTags(NodeUtility.GetAllNodesWithTag(articleContent, "h1"), "h2");
+            NodeUtility.ReplaceNodeTags(articleContent.QuerySelectorAll("h1"), "h2");
 
             // Remove extra paragraphs
             NodeUtility.RemoveNodes(articleContent.GetElementsByTagName("p"), (paragraph) =>
@@ -591,7 +591,7 @@ namespace SmartReader
                 return totalCount == 0 && string.IsNullOrEmpty(NodeUtility.GetInnerText(paragraph, false));
             });
 
-            NodeUtility.ForEachElement(NodeUtility.GetAllNodesWithTag(articleContent, "br"), (br) =>
+            NodeUtility.ForEachElement(articleContent.QuerySelectorAll("br"), br =>
             {
                 var next = NodeUtility.NextElement(br.NextSibling, RE_Whitespace);
                 if (next is { TagName: "P" })
@@ -599,7 +599,7 @@ namespace SmartReader
             });
 
             // Remove single-cell tables
-            NodeUtility.ForEachElement(NodeUtility.GetAllNodesWithTag(articleContent, "table"), (tableEl) =>
+            NodeUtility.ForEachElement(articleContent.QuerySelectorAll("table"), (tableEl) =>
             {
                 var tbody = NodeUtility.HasSingleTagInsideElement(tableEl, "TBODY") ? tableEl.FirstElementChild! : tableEl;
                 if (NodeUtility.HasSingleTagInsideElement(tbody, "TR"))
@@ -1794,7 +1794,7 @@ namespace SmartReader
             //   <br>
             //   Sentences<br>
             // </div>
-            var brNodes = NodeUtility.GetAllNodesWithTag(doc.DocumentElement, "div > br");
+            var brNodes = doc.DocumentElement.QuerySelectorAll("div > br");
             IEnumerable<IElement> totalNodes = nodes;
             if (brNodes.Length > 0)
             {

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -1949,16 +1949,21 @@ namespace SmartReader
                 throw new HttpRequestException($"Cannot GET resource {resource}. StatusCode: {response.StatusCode}");
             }
 
-            var headLan = response.Headers.FirstOrDefault(x => x.Key.Equals("content-language", StringComparison.OrdinalIgnoreCase));
-            if (headLan.Value != null && headLan.Value.Any())
-                language = headLan.Value.ElementAt(0);
-
-            var headCont = response.Headers.FirstOrDefault(x => x.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase));
-            if (headCont.Value != null && headCont.Value.Any())
+            if (response.Headers.TryGetValues("Content-Language", out var contentLanguageHeader))
             {
-                int index = headCont.Value.ElementAt(0).IndexOf("charset=");
-                if (index != -1)
-                    charset = headCont.Value.ElementAt(0).Substring(index + 8);
+                language = contentLanguageHeader.First();
+            }
+
+            if (response.Headers.TryGetValues("Content-Type", out var contentTypeHeader))
+            {
+                string contentType = contentTypeHeader.First();
+
+                int charSetIndex = contentType.IndexOf("charset=");
+
+                if (charSetIndex != -1)
+                {
+                    charset = contentType.Substring(charSetIndex + 8);
+                }
             }
 
             return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -202,7 +202,7 @@ namespace SmartReader
         {
             this.uri = new Uri(uri);
                         
-            var context = BrowsingContext.New(Configuration.Default.WithCss());
+            var context = BrowsingContext.New(Configuration.Default);
             var parser = new HtmlParser(new HtmlParserOptions(), context);
             doc = parser.ParseDocument(text);
 
@@ -221,7 +221,7 @@ namespace SmartReader
         {
             this.uri = new Uri(uri);
             
-            var context = BrowsingContext.New(Configuration.Default.WithCss());
+            var context = BrowsingContext.New(Configuration.Default);
             var parser = new HtmlParser(new HtmlParserOptions(), context);
             doc = parser.ParseDocument(source);
 
@@ -304,7 +304,7 @@ namespace SmartReader
         /// </returns>    
         public async Task<Article> GetArticleAsync()
         {
-            var context = BrowsingContext.New(Configuration.Default.WithCss());
+            var context = BrowsingContext.New(Configuration.Default);
             var parser = new HtmlParser(new HtmlParserOptions(), context);
             
             if (doc is null)
@@ -324,7 +324,7 @@ namespace SmartReader
                 
         public Article GetArticle()
         {
-            var context = BrowsingContext.New(Configuration.Default.WithCss());
+            var context = BrowsingContext.New(Configuration.Default);
             var parser = new HtmlParser(new HtmlParserOptions(), context);
 
             if (doc is null)
@@ -364,7 +364,7 @@ namespace SmartReader
             var smartReader = new Reader(uri).SetCustomUserAgent(userAgent);
 
             var stream = smartReader.GetStreamAsync(new Uri(uri)).GetAwaiter().GetResult();
-            var context = BrowsingContext.New(Configuration.Default.WithCss());
+            var context = BrowsingContext.New(Configuration.Default);
             var parser = new HtmlParser(new HtmlParserOptions(), context);
 
             smartReader.doc = parser.ParseDocument(stream);

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -466,7 +466,7 @@ namespace SmartReader
                 // If we find a <br> chain, remove the <br>s until we hit another element
                 // or non-whitespace. This leaves behind the first <br> in the chain
                 // (which will be replaced with a <p> later).
-                while ((next = NodeUtility.NextElement(next, RE_Whitespace)) != null && (((IElement)next).TagName is "BR"))
+                while ((next = NodeUtility.NextElement(next, RE_Whitespace)) is { NodeName: "BR" })
                 {
                     replaced = true;
                     var brSibling = next.NextSibling;
@@ -489,7 +489,7 @@ namespace SmartReader
                         if ((next as IElement)?.TagName is "BR")
                         {
                             var nextElem = NodeUtility.NextElement(next.NextSibling, RE_Whitespace);
-                            if (nextElem != null && nextElem.TagName is "BR")
+                            if (nextElem is { TagName: "BR" })
                                 break;
                         }
 
@@ -594,7 +594,7 @@ namespace SmartReader
             NodeUtility.ForEachElement(NodeUtility.GetAllNodesWithTag(articleContent, "br"), (br) =>
             {
                 var next = NodeUtility.NextElement(br.NextSibling, RE_Whitespace);
-                if (next != null && next.TagName is "P")
+                if (next is { TagName: "P" })
                     br.Parent!.RemoveChild(br);
             });
 
@@ -907,7 +907,7 @@ namespace SmartReader
                         continue;
 
                     // If this paragraph is less than 25 characters, don't even count it.
-                    string innerText = NodeUtility.GetInnerText((IElement)elementToScore);
+                    string innerText = NodeUtility.GetInnerText(elementToScore);
                     if (innerText.Length < 25)
                         continue;
 
@@ -1040,7 +1040,7 @@ namespace SmartReader
                                 topCandidate = parentOfTopCandidate;
                                 break;
                             }
-                            parentOfTopCandidate = (IElement)parentOfTopCandidate.Parent!;
+                            parentOfTopCandidate = parentOfTopCandidate.ParentElement!;
                         }
                     }
                     
@@ -1056,7 +1056,7 @@ namespace SmartReader
                     // lurking in other places that we want to unify in. The sibling stuff
                     // below does some of that - but only if we've looked high enough up the DOM
                     // tree.
-                    parentOfTopCandidate = (IElement)topCandidate.Parent!;
+                    parentOfTopCandidate = topCandidate.ParentElement!;
                     
                     var lastScore = GetReadabilityScore(topCandidate);
                     // The scores shouldn't get too low.
@@ -1065,7 +1065,7 @@ namespace SmartReader
                     {                        
                         if (GetReadabilityScore(parentOfTopCandidate).CompareTo(0.0) == 0)
                         {
-                            parentOfTopCandidate = (IElement)parentOfTopCandidate.Parent!;
+                            parentOfTopCandidate = parentOfTopCandidate.ParentElement!;
                             continue;
                         }
                         
@@ -1080,16 +1080,16 @@ namespace SmartReader
                         }
                         
                         lastScore = GetReadabilityScore(parentOfTopCandidate);
-                        parentOfTopCandidate = (IElement)parentOfTopCandidate.Parent!;
+                        parentOfTopCandidate = parentOfTopCandidate.ParentElement!;
                     }
 
                     // If the top candidate is the only child, use parent instead. This will help sibling
                     // joining logic when adjacent content is actually located in parent's sibling node.
-                    parentOfTopCandidate = (IElement)topCandidate.Parent!;
+                    parentOfTopCandidate = topCandidate.ParentElement!;
                     while (parentOfTopCandidate.TagName is not "BODY" && parentOfTopCandidate.Children.Length == 1)
                     {
                         topCandidate = parentOfTopCandidate;
-                        parentOfTopCandidate = (IElement)topCandidate.Parent!;
+                        parentOfTopCandidate = topCandidate.ParentElement!;
                     }
                     
                     if (GetReadabilityScore(topCandidate).CompareTo(0.0) == 0)
@@ -1282,7 +1282,7 @@ namespace SmartReader
             var weight = 0;
 
             // Look for a special classname
-            if (e.ClassName != null && e.ClassName is not "")
+            if (!string.IsNullOrEmpty(e.ClassName))
             {
                 if (RE_Negative.IsMatch(e.ClassName))
                     weight -= 25;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -608,7 +608,7 @@ namespace SmartReader
                     if (NodeUtility.HasSingleTagInsideElement(row, "TD"))
                     {
                         var cell = row.FirstElementChild!;
-                        cell = NodeUtility.SetNodeTag(cell, NodeUtility.EveryNode(cell.ChildNodes, NodeUtility.IsPhrasingContent) ? "P" : "DIV");
+                        cell = NodeUtility.SetNodeTag(cell, cell.ChildNodes.All(NodeUtility.IsPhrasingContent) ? "P" : "DIV");
                         tableEl.Parent!.ReplaceChild(cell, tableEl);
                     }
                 }

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -1591,7 +1591,12 @@ namespace SmartReader
             }
             var childrenLength = 0;
             var children = NodeUtility.GetAllNodesWithTag(e, tags);
-            NodeUtility.ForEachElement(children, (child) => childrenLength += NodeUtility.GetInnerText(child, true).Length);
+
+            foreach (var child in children)
+            {
+                childrenLength += NodeUtility.GetInnerText(child, true).Length;
+            }
+
             return childrenLength / textLength;
         }
 
@@ -1616,7 +1621,11 @@ namespace SmartReader
                 {
                     var listLength = 0;
                     var listNodes = NodeUtility.GetAllNodesWithTag(node, s_ul_ol);
-                    NodeUtility.ForEachElement(listNodes, (list) => listLength += NodeUtility.GetInnerText(list).Length);
+                    
+                    foreach (var list in listNodes)
+                    {
+                        listLength += NodeUtility.GetInnerText(list).Length;
+                    }
                     
                     if (NodeUtility.GetInnerText(node).Length > 0)
                         isList = listLength / NodeUtility.GetInnerText(node).Length > 0.9;

--- a/src/SmartReader/SmartReader.cs
+++ b/src/SmartReader/SmartReader.cs
@@ -455,7 +455,7 @@ namespace SmartReader
         /// </summary>
         private void ReplaceBrs(IElement elem)
         {
-            NodeUtility.ForEachElement(elem.QuerySelectorAll("br"), br =>
+            NodeUtility.ForEachElement(elem.GetElementsByTagName("br"), br =>
             {
                 var next = br.NextSibling;
 
@@ -576,7 +576,7 @@ namespace SmartReader
             CleanConditionally(articleContent, "div");
 
             // replace H1 with H2 as H1 should be only title that is displayed separately
-            NodeUtility.ReplaceNodeTags(articleContent.QuerySelectorAll("h1"), "h2");
+            NodeUtility.ReplaceNodeTags(articleContent.GetElementsByTagName("h1"), "h2");
 
             // Remove extra paragraphs
             NodeUtility.RemoveNodes(articleContent.GetElementsByTagName("p"), (paragraph) =>
@@ -591,7 +591,7 @@ namespace SmartReader
                 return totalCount == 0 && string.IsNullOrEmpty(NodeUtility.GetInnerText(paragraph, false));
             });
 
-            NodeUtility.ForEachElement(articleContent.QuerySelectorAll("br"), br =>
+            NodeUtility.ForEachElement(articleContent.GetElementsByTagName("br"), br =>
             {
                 var next = NodeUtility.NextElement(br.NextSibling, RE_Whitespace);
                 if (next is { TagName: "P" })
@@ -599,7 +599,7 @@ namespace SmartReader
             });
 
             // Remove single-cell tables
-            NodeUtility.ForEachElement(articleContent.QuerySelectorAll("table"), (tableEl) =>
+            NodeUtility.ForEachElement(articleContent.GetElementsByTagName("table"), (tableEl) =>
             {
                 var tbody = NodeUtility.HasSingleTagInsideElement(tableEl, "TBODY") ? tableEl.FirstElementChild! : tableEl;
                 if (NodeUtility.HasSingleTagInsideElement(tbody, "TR"))

--- a/src/SmartReader/SmartReader.csproj
+++ b/src/SmartReader/SmartReader.csproj
@@ -37,7 +37,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.1" />
-    <PackageReference Include="AngleSharp.Css" Version="0.16.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -574,7 +574,7 @@ namespace SmartReader
             return Tuple.Create(rows, columns);
         }
 
-        internal static IList<IElement> GetElementAncestors(IElement node, int maxDepth = 0)
+        internal static List<IElement> GetElementAncestors(IElement node, int maxDepth = 0)
         {
             var i = 0;
             var ancestors = new List<IElement>();
@@ -588,7 +588,7 @@ namespace SmartReader
             return ancestors;
         }
 
-        internal static IList<INode> GetNodeAncestors(INode node, int maxDepth = 0)
+        internal static List<INode> GetNodeAncestors(INode node, int maxDepth = 0)
         {
             var i = 0;
             var ancestors = new List<INode>();

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using AngleSharp.Css.Dom;
@@ -131,57 +132,15 @@ namespace SmartReader
             for (int a = 0; a < nodeList?.Length; a++)
             {
                 fn(nodeList[a]);
-            }
-            
+            }            
         }
 
         internal static void ForEachNode(IEnumerable<INode> nodeList, Action<INode, int> fn, int level)
         {
             foreach (var node in nodeList)
                 fn(node, level++);
-        }       
-
-        /// <summary>
-        /// <para>Iterate over a NodeList, and return the first node that passes
-        /// the supplied test function.</para>		
-        /// <para>For convenience, the current object context is applied to the
-        /// provided test function.</para>
-        /// </summary>
-        /// <param name="elementList">The nodes to operate on</param>
-        /// <param name="fn">The test function</param>
-        /// <returns>INode</returns>
-        internal static IElement? FindNode(IHtmlCollection<IElement> elementList, Func<IElement, bool> fn)
-        {
-            foreach (var node in elementList)
-            {
-                if (fn(node))
-                    return node;
-            }
-
-            return null;
         }
-
-        /// <summary>
-        /// <para>Iterate over a NodeList, return true if all of the provided iterate
-        /// function calls return true, false otherwise.</para>		
-        /// <para>For convenience, the current object context is applied to the
-        /// provided iterate function.</para>
-        /// </summary>
-        /// <param name="nodeList">The nodes to operate on</param>
-        /// <param name="fn">The iterate function</param>
-        /// <returns>bool</returns>
-        internal static bool EveryNode(INodeList nodeList, Func<INode, bool> fn)
-        {
-            if (nodeList is null) return false;
-
-            foreach (var node in nodeList)
-            {
-                if (!fn(node)) return false;
-            }
-           
-            return true;
-        }
-
+       
         /// <summary>        
         /// Concat all nodelists passed as arguments.
         /// </summary>
@@ -385,8 +344,7 @@ namespace SmartReader
         internal static bool IsPhrasingContent(INode node)
         {
             return node.NodeType == NodeType.Text || phrasingElems.Contains(node.NodeName) ||
-              ((node.NodeName is "A" or "DEL" or "INS") &&
-                EveryNode(node.ChildNodes, IsPhrasingContent));
+              (node.NodeName is "A" or "DEL" or "INS" && node.ChildNodes.All(IsPhrasingContent));
         }
 
         internal static bool IsWhitespace(INode node)

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 
@@ -121,7 +120,6 @@ namespace SmartReader
             }
 
             return null;
-
         }
 
         /// <summary>

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -163,11 +163,6 @@ namespace SmartReader
             return node.QuerySelectorAll(string.Join(",", tagNames));
         }
 
-        internal static IHtmlCollection<IElement> GetAllNodesWithTag(IElement node, string tagName)
-        {
-            return node.QuerySelectorAll(tagName);
-        }
-
         /// <summary>
         /// Check if node is image, or if node contains exactly only one image
         /// whether as a direct child or as its descendants.

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -129,7 +129,7 @@ namespace SmartReader
         /// <return>void</return>
         internal static void ForEachElement(IHtmlCollection<IElement> nodeList, Action<IElement> fn)
         {
-            for (int a = 0; a < nodeList?.Length; a++)
+            for (int a = 0; a < nodeList.Length; a++)
             {
                 fn(nodeList[a]);
             }            
@@ -187,7 +187,7 @@ namespace SmartReader
             // Find img without source or attributes that might contains image, and remove it.
             // This is done to prevent a placeholder img is replaced by img from noscript in next step.           
             var imgs = doc.GetElementsByTagName("img");
-            ForEachElement(imgs, (img) => {
+            ForEachElement(imgs, static img => {
                 for (var i = 0; i < img.Attributes.Length; i++)
                 {
                     var attr = img.Attributes[i]!;
@@ -208,18 +208,20 @@ namespace SmartReader
            
             // Next find noscript and try to extract its image
             var noscripts = doc.GetElementsByTagName("noscript");
-            ForEachElement(noscripts, noscript => {               
+            ForEachElement(noscripts, static noscript => {
                 // Parse content of noscript and make sure it only contains image
+                var doc = (IHtmlDocument)noscript.GetRoot();
+
                 var tmp = doc.CreateElement("div");
                 tmp.InnerHtml = noscript.InnerHtml;
+
                 if (!IsSingleImage(tmp))
                     return;
 
                 // If noscript has previous sibling and it only contains image,
                 // replace it with noscript content. However we also keep old
                 // attributes that might contains image.
-                var prevElement = noscript.PreviousElementSibling;
-                if (prevElement != null && IsSingleImage(prevElement))
+                if (noscript.PreviousElementSibling is IElement prevElement && IsSingleImage(prevElement))
                 {
                     var prevImg = prevElement;
                     if (prevImg.TagName is not "IMG")
@@ -265,7 +267,7 @@ namespace SmartReader
         /// <param name="element">The element to operate on</param>
         internal static void RemoveScripts(IElement element)
         {
-            RemoveNodes(element.GetElementsByTagName("script"), scriptNode =>
+            RemoveNodes(element.GetElementsByTagName("script"), static scriptNode =>
             {
                 scriptNode.NodeValue = "";
                 scriptNode.RemoveAttribute("src");

--- a/src/SmartReader/Utility.cs
+++ b/src/SmartReader/Utility.cs
@@ -432,12 +432,12 @@ namespace SmartReader
             double linkLength = 0;
 
             // XXX implement _reduceNodeList?
-            ForEachElement(element.GetElementsByTagName("a"), (linkEl) =>
+            foreach (var linkEl in element.GetElementsByTagName("a"))
             {
                 var href = linkEl.GetAttribute("href");
                 var coefficient = href is { Length: > 0 } && RE_HashUrl.IsMatch(href) ? 0.3 : 1; 
                 linkLength += GetInnerText(linkEl).Length * coefficient;
-            });
+            }
 
             return linkLength / textLength;
         }

--- a/src/SmartReaderTests/test-pages/ehow-1/expected.html
+++ b/src/SmartReaderTests/test-pages/ehow-1/expected.html
@@ -1,5 +1,102 @@
 <div id="readability-page-1" class="page"><div>
+            <header>
+                
+                
+                
+            </header>
+            <div>
                     <p>Glass cloche terrariums are not only appealing to the eye, but they also preserve a bit of nature in your home and serve as a simple, yet beautiful, piece of art. Closed terrariums are easy to care for, as they retain much of their own moisture and provide a warm environment with a consistent level of humidity. You won’t have to water the terrariums unless you see that the walls are not misting up. Small growing plants that don’t require a lot of light work best such as succulents, ferns, moss, even orchids.</p>
                     <figure> <img src="http://img-aws.ehowcdn.com/640/cme/photography.prod.demandstudios.com/16149374-814f-40bc-baf3-ca20f149f0ba.jpg" alt="Glass cloche terrariums" title="Glass cloche terrariums" data-credit="Lucy Akins " longdesc="http://s3.amazonaws.com/photography.prod.demandstudios.com/16149374-814f-40bc-baf3-ca20f149f0ba.jpg"> </figure>
                     <figcaption> Glass cloche terrariums (Lucy Akins) </figcaption>
-                </div></div>
+                </div>
+            <div id="relatedContentUpper" data-module="rcp_top">
+                <header>
+                    <h3>Other People Are Reading</h3> </header>
+                
+            </div>
+            <div> <p><span>What You'll Need:</span></p><ul>
+                            <li>Cloche</li>
+                            <li>Planter saucer, small shallow dish or desired platform</li>
+                            <li>Floral foam oasis</li>
+                            <li>Ruler </li>
+                            <li>Spoon</li>
+                            <li>Floral wire pins or paper clips</li>
+                            <li>Small plants (from a florist or nursery)</li>
+                            <li>Moss</li>
+                            <li>Tweezers</li>
+                            <li>Other small decorative items (optional)</li>
+                        </ul>
+                    </div>
+            <div>
+                    <div> <p><span>Step 1</span></p><p>Measure the circumference of your cloche and cut the foam oasis about 3/4 inch (2 cm) smaller. Place the foam oasis into a container full of water and allow to soak until it sinks to the bottom. Dig out a hole on the oasis large enough to fit your plant, being careful not to pierce all the way through to the bottom.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/fc249ef6-4d27-41b4-8c21-15f7a8512b50.jpg" alt="Dig a hole in the oasis." data-credit="Lucy Akins"> </figure>
+                    <figcaption> Dig a hole in the oasis. (Lucy Akins) </figcaption>
+                </div>
+            
+            
+            <div>
+                    <div> <p><span>Step 2</span></p><p>Insert your plant into the hole.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/aae11d4d-a4aa-4251-a4d9-41023ebf6d84.jpg" alt="Orchid in foam oasis" data-credit="Lucy Akins"> </figure>
+                    <figcaption> Orchid in foam oasis (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 3</span></p><p>You can add various plants if you wish.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/7afdfa1e-da74-44b5-b89c-ca8123516272.jpg" alt="Various foliage" data-credit="Lucy Akins"> </figure>
+                    <figcaption> Various foliage (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 4</span></p><p>Using floral pins, attach enough moss around the oasis to cover it.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/4f6612c0-316a-4c74-bb03-cb4e778f6d72.jpg" alt="Attach moss." data-credit="Lucy Akins"> </figure>
+                    <figcaption> Attach moss. (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 5</span></p><p>Gently place the cloche over the oasis. The glass may push some of the moss upward, exposing some of the foam.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/eeb1e0b4-e573-40a3-8db1-2c76f0b13b84.jpg" alt="Place cloche over oasis." data-credit="Lucy Akins"> </figure>
+                    <figcaption> Place cloche over oasis. (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 6</span></p><p>Simply pull down the moss with tweezers or insert more moss to fill in the empty spaces.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/812d4649-4152-4363-97c0-f181d02e709a.jpg" alt="Rearrange moss." data-credit="Lucy Akins"> </figure>
+                    <figcaption> Rearrange moss. (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 7</span></p><p>You can use any platform you wish. In this case, a small saucer was used.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/default/cme/photography.prod.demandstudios.com/0cb3988c-9318-47d6-bc9c-c798da1ede72.jpg" alt="Place cloche on a platform to sit on." data-credit="Lucy Akins"> </figure>
+                    <figcaption> Place cloche on a platform to sit on. (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 8</span></p><p>This particular terrarium rests on a planter saucer and features a small white pumpkin.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/640/cme/photography.prod.demandstudios.com/e3e18f0b-ab2c-4ffb-9988-a1ea63faef8b.jpg" alt="Cloche placed on a terracotta saucer" data-credit="Lucy Akins"> </figure>
+                    <figcaption> Cloche placed on a terracotta saucer (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Step 9</span></p><p>This particular terrarium was placed on a wood slice and a little toy squirrel was placed inside to add a little whimsy.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/640/cme/photography.prod.demandstudios.com/2cd79f8d-0d16-4573-8861-e47fb74b0638.jpg" alt="Placed on a wooden slice" data-credit="Lucy Akins"> </figure>
+                    <figcaption> Placed on a wooden slice (Lucy Akins) </figcaption>
+                </div>
+            <div>
+                    <div> <p><span>Finished Terrarium</span></p><p>Displayed alone or in a group, these pretty arrangements allow you to add a little nature to your decor or tablescape.</p>
+                    </div>
+                    <figure> <img src="http://img-aws.ehowcdn.com/640/cme/photography.prod.demandstudios.com/78670312-8636-4c42-a75c-3029f7aa6c73.jpg" alt="Cloche terrarium" data-credit="Lucy Akins"> </figure>
+                    <figcaption> Cloche terrarium (Lucy Akins) </figcaption>
+                </div>
+            
+            
+            
+            
+            
+            
+            <section id="FeaturedTombstone" data-module="rcp_tombstone">
+                <h2>Featured</h2>
+                
+            </section>
+        </div></div>

--- a/src/SmartReaderTests/test-pages/ehow-2/expected-metadata.json
+++ b/src/SmartReaderTests/test-pages/ehow-2/expected-metadata.json
@@ -5,7 +5,7 @@
   "excerpt": "How to Throw a Graduation Party on a Budget. Graduation parties are a great way to commemorate the years of hard work teens and college co-eds devote to education. They’re also costly for mom and dad.The average cost of a graduation party in 2013 was a whopping $1,200, according to Graduationparty.com; $700 of that was allocated for food....",
   "readerable": true,
   "language": "en-US",
-  "timeToRead": "00:01:00",
+  "timeToRead": "00:03:00",
   "publicationDate": null,
   "author": "Gina Roberts-Grey",
   "siteName": "eHow",

--- a/src/SmartReaderTests/test-pages/ehow-2/expected.html
+++ b/src/SmartReaderTests/test-pages/ehow-2/expected.html
@@ -1,5 +1,148 @@
-<div id="readability-page-1" class="page"><div>
+<div id="readability-page-1" class="page"><div data-type="AuthorProfile">
+                <div>
+                    <p><a id="img-follow-tip" href="https://localhost/contributor/gina_robertsgrey/" target="_top">
+                        <img src="https://img-aws.ehowcdn.com/60x60/cme/cme_public_images/www_demandstudios_com/sitelife.studiod.com/ver1.0/Content/images/store/9/2/d9dd6f61-b183-4893-927f-5b540e45be91.Small.jpg" data-failover="//img-aws.ehowcdn.com/60x60/ehow-cdn-assets/test15/media/images/authors/missing-author-image.png" onerror="var failover = this.getAttribute('data-failover');
+                if (failover) failover = failover.replace(/^https?:/,'');
+                var src = this.src ? this.src.replace(/^https?:/,'') : '';
+                if (src != failover){
+                    this.src = failover;
+                }"> </a></p>
+                </div>
+                
+                <p><time datetime="2016-09-14T07:07:00-04:00" itemprop="dateModified">Last updated September 14, 2016</time>
+                </p>
+                
+            </div><div>
+            <article data-type="article">
+                <div>
+                        <div>
                             <p>Graduation parties are a great way to commemorate the years of hard work teens and college co-eds devote to education. They’re also costly for mom and dad.</p>
                             <p>The average cost of a graduation party in 2013 was a whopping $1,200, according to Graduationparty.com; $700 of that was allocated for food. However that budget was based on Midwestern statistics, and parties in urban areas like New York City are thought to have a much higher price tag.</p>
                             <p>Thankfully, there are plenty of creative ways to trim a little grad party fat without sacrificing any of the fun or celebratory spirit.</p>
-                        </div></div>
+                        </div>
+                        <figure>
+                            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/2F/86/5547EF62-EAF5-4256-945D-0496F61C862F/5547EF62-EAF5-4256-945D-0496F61C862F.jpg" alt="Graduation" title="Graduation" data-credit="Mike Watson Images/Moodboard/Getty " longdesc="http://s3.amazonaws.com/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/2F/86/5547EF62-EAF5-4256-945D-0496F61C862F/5547EF62-EAF5-4256-945D-0496F61C862F.jpg" data-pin-ehow-hover="true" data-pin-no-hover="true">
+                        </figure>
+                        <figcaption>
+                            (Mike Watson Images/Moodboard/Getty)
+                        </figcaption>
+                    </div>
+                <!-- gpt slot 640x120_ATF -->
+                
+                <span>
+<span>
+<div>
+<p><span><p>Parties hosted at restaurants, clubhouses and country clubs eliminate the need to spend hours cleaning up once party guests have gone home. But that convenience comes with a price tag. A country club may charge as much as $2,000 for room rental and restaurant food and beverage will almost always cost more than food prepped and served at home.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/FE/CB/121569D2-6984-4B2F-83C4-9D2D9A27CBFE/121569D2-6984-4B2F-83C4-9D2D9A27CBFE.jpg" alt="Save money hosting the party at home." data-credit="Thomas Jackson/Digital Vision/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Thomas Jackson/Digital Vision/Getty Images </figcaption>
+        </div>
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Instead of hiring a DJ, use your iPod or Smartphone to spin the tunes. Both easily hook up to most speakers or mp3 compatible docks to play music from your music library. Or download Pandora, the free online radio app, and play hours of music for free.</p>
+<p>Personalize the music with a playlist of the grad’s favorite songs or songs that were big hits during his or her years in school.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/DF/FC/A05B0252-BD73-4BC7-A09A-96F0A504FCDF/A05B0252-BD73-4BC7-A09A-96F0A504FCDF.jpg" alt="Online radio can take the place of a hired DJ." data-credit="Spencer Platt/Getty Images News/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Spencer Platt/Getty Images News/Getty Images </figcaption>
+        </div>
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Avoid canned drinks, which guests often open, but don't finish. Serve pitchers of tap water with lemon and cucumber slices or sliced strawberries for an interesting and refreshing flavor. Opt for punches and non-alcoholic drinks for high school graduates that allow guests to dole out the exact amount they want to drink.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/EB/DB/8A04CCA7-3255-4225-B59A-C41441F8DBEB/8A04CCA7-3255-4225-B59A-C41441F8DBEB.jpg" alt="Serve drinks in pitchers, not in cans." data-credit="evgenyb/iStock/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            evgenyb/iStock/Getty Images </figcaption>
+        </div>
+        
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Instead of inviting everyone you – and the graduate – know or ever knew, scale back the guest list. Forgo inviting guests that you or your grad haven't seen for eons. There is no reason to provide provisions for people who are essentially out of your lives. Sticking to a small, but personal, guest list allows more time to mingle with loved ones during the party, too.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/94/10/08035476-0167-4A03-AADC-13A7E7AA1094/08035476-0167-4A03-AADC-13A7E7AA1094.jpg" alt="Limit guests to those close to the graduate." data-credit="Kane Skennar/Photodisc/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Kane Skennar/Photodisc/Getty Images </figcaption>
+        </div>
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>See if your grad and his best friend, girlfriend or close family member would consider hosting a joint party. You can split some of the expenses, especially when the two graduates share mutual friends. You'll also have another parent to bounce ideas off of and to help you stick to your budget when you're tempted to splurge.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/06/49/4AD62696-FC95-4DA2-8351-42740C7B4906/4AD62696-FC95-4DA2-8351-42740C7B4906.jpg" alt="Throw a joint bash for big savings." data-credit="Mike Watson Images/Moodboard/Getty" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Mike Watson Images/Moodboard/Getty </figcaption>
+        </div>
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Skip carving stations of prime rib and jumbo shrimp as appetizers, especially for high school graduation parties. Instead, serve some of the graduate's favorite side dishes that are cost effective, like a big pot of spaghetti with breadsticks. Opt for easy and simple food such as pizza, finger food and mini appetizers. </p>
+<p>Avoid pre-packaged foods and pre-made deli platters. These can be quite costly. Instead, make your own cheese and deli platters for less than half the cost of pre-made.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/D0/51/B6AED06C-5E19-4A26-9AAD-0E175F6251D0/B6AED06C-5E19-4A26-9AAD-0E175F6251D0.jpg" alt="Cost effective appetizers are just as satisfying as pre-made deli platters." data-credit="Mark Stout/iStock/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Mark Stout/iStock/Getty Images </figcaption>
+        </div>
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Instead of an evening dinner party, host a grad lunch or all appetizers party. Brunch and lunch fare or finger food costs less than dinner. Guests also tend to consume less alcohol in the middle of the day, which keeps cost down.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/35/B4/DD5FD05A-B631-4AFE-BC8F-FDACAD1EB435/DD5FD05A-B631-4AFE-BC8F-FDACAD1EB435.jpg" alt="A brunch gathering will cost less than a dinner party." data-credit="Mark Stout/iStock/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            Mark Stout/iStock/Getty Images </figcaption>
+        </div>
+        <div id="relatedContentUpper" data-module="rcp_top">
+            <header>
+                <h3>Other People Are Reading</h3>
+            </header>
+            
+        </div>
+        
+        </span>
+        </span>
+        <span>
+<span>
+<div>
+<p><span><p>Decorate your party in the graduate's current school colors or the colors of the school he or she will be headed to next. Décor that is not specifically graduation-themed may cost a bit less, and any leftovers can be re-used for future parties, picnics and events.</p></span> </p>
+        <figure>
+            <img src="https://img-aws.ehowcdn.com/640/cme/cme_public_images/www_ehow_com/cdn-write.demandstudios.com/upload/image/A1/FA/2C368B34-8F6A-45F6-9DFC-0B0C4E33FAA1/2C368B34-8F6A-45F6-9DFC-0B0C4E33FAA1.jpg" alt="Theme the party by color without graduation-specific decor." data-credit="jethuynh/iStock/Getty Images" data-pin-ehow-hover="true" data-pin-no-hover="true">
+        </figure>
+        <figcaption>
+            jethuynh/iStock/Getty Images </figcaption>
+        </div>
+        </span>
+        </span>
+        
+        
+        <h2>
+            <a target="_blank" href="https://www.google.com/adsense/support/bin/request.py?contact=abg_afc&amp;url=http://ehow.com/&amp;hl=en&amp;client=ehow&amp;gl=US">Related Searches</a>
+        </h2>
+        
+        
+        <p>Promoted By Zergnet</p>
+        
+        </article>
+        </div></div>

--- a/src/SmartReaderTests/test-pages/engadget/expected.html
+++ b/src/SmartReaderTests/test-pages/engadget/expected.html
@@ -1,4 +1,69 @@
 <div id="readability-page-1" class="page"><div>
+                                                        <p>The <a href="https://www.engadget.com/2017/06/13/the-xbox-one-x-is-aspirational-in-the-purest-sense-of-the-word/">Xbox
+                                                                One X</a> is the ultimate video game system. It sports
+                                                                more horsepower than any system ever. And it plays more
+                                                                titles in native 4K than <a href="https://www.engadget.com/2016/11/07/sony-playstation-4-pro-review/">Sony's
+                                                                    PlayStation 4 Pro</a>. It's just about everything
+                                                                you could want without investing in a gaming PC. The
+                                                                only problem? It's now been a year since the PS4 Pro
+                                                                launched, and the One X costs $500, while Sony's console
+                                                                launched at $400. That high price limits the Xbox One X
+                                                                to diehard Microsoft fans who don't mind paying a bit
+                                                                more to play the console's exclusive titles in 4K.
+                                                                Everyone else might be better off waiting, or opting for
+                                                                the $279 <a href="https://www.engadget.com/2016/08/02/xbox-one-s-review/">Xbox
+                                                                    One S</a>. </p>
+                                                    </div><section>
+                                                            <h4> Gallery: Xbox One
+                                                                X | 14 Photos </h4>
+                                                            <div data-behavior="lightbox_trigger" data-engadget-slideshow-id="803271" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142088,&quot;index&quot;:0}" data-eng-mn="93511844"><p><a href="#" data-index="0" data-engadget-slide-id="7142088" data-eng-bang="{&quot;gallery&quot;:803271,&quot;slide&quot;:7142088,&quot;index&quot;:0}">
+                                                                <img src="https://o.aolcdn.com/images/dims?thumbnail=980%2C653&amp;quality=80&amp;image_uri=https%3A%2F%2Fs.blogcdn.com%2Fslideshows%2Fimages%2Fslides%2F714%2F208%2F8%2FS7142088%2Fslug%2Fl%2Fxbox-one-x-review-gallery-1-1.jpg&amp;client=cbc79c14efcebee57402&amp;signature=9bb08b52e12de8e4060f863a52c613489529818d">
+                                                            </a></p>
+                                                                
+                                                            </div>
+                                                        </section><div>
+                                                        
+                                                        
+                                                        <div>
+                                                                <div>
+                                                                    
+                                                                    <ul>
+                                                                        <li>Most
+                                                                            powerful hardware ever in a home console
+                                                                        </li>
+                                                                        <li>Solid
+                                                                            selection of enhanced titles
+                                                                        </li>
+                                                                        <li>4K Blu-ray
+                                                                            drive is great for movie fans
+                                                                        </li>
+                                                                    </ul>
+                                                                </div>
+                                                                <div>
+                                                                    
+                                                                    <ul>
+                                                                        <li>Expensive
+                                                                        </li>
+                                                                        <li>Not worth
+                                                                            it if you don’t have a 4K TV
+                                                                        </li>
+                                                                        <li>Still no VR
+                                                                            support
+                                                                        </li>
+                                                                    </ul>
+                                                                </div>
+                                                            </div>
+                                                        <div>
+                                                            
+                                                            <p>As promised, the Xbox One X is the
+                                                                most powerful game console ever. In practice, though, it
+                                                                really just puts Microsoft on equal footing with Sony’s
+                                                                PlayStation 4 Pro. 4K/HDR enhanced games look great, but
+                                                                it’s lack of VR is disappointing in 2017.</p>
+                                                        </div>
+                                                    </div><div>
+                                                <!-- continued contents -->
+                                                <div>
                                                                 <h3>Hardware</h3>
                                                                 <p><img data-credit="Devindra Hardawar/AOL" data-mep="2181678" src="https://o.aolcdn.com/images/dims?crop=1600%2C1067%2C0%2C0&amp;quality=85&amp;format=jpg&amp;resize=1600%2C1067&amp;image_uri=http%3A%2F%2Fo.aolcdn.com%2Fhss%2Fstorage%2Fmidas%2F93beb86758ae1cf95721699e1e006e35%2F205826074%2FXbox%2BOne%2BX%2Breview%2Bgallery%2B7.jpg&amp;client=a1acac3e1b3290917d92&amp;signature=c0f2d36259c2c1decfb60aae364527cda2560d4a" alt=""></p>
                                                                 <p>Despite all the power inside, the One X is
@@ -28,7 +93,14 @@
                                                                     out, and gigabit Ethernet. If you've still got a
                                                                     Kinect around, you'll need to use a USB adapter to
                                                                     plug it in.</p>
-                                                            </div><div>
+                                                            </div>
+                                                <div data-engadget-breakout-type="image">
+                                                            <figure><img src="https://o.aolcdn.com/images/dims?resize=980%2C640&amp;quality=100&amp;image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D1599%252C1043%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1043%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252F8b98ec8f6649158fe7448ac2f2695ac5%252F205826072%252FXbox%252BOne%252BX%252Breview%252Bgallery%252B6.jpg%26client%3Da1acac3e1b3290917d92%26signature%3D353dad1308f98c2c9dfc82c58a540a8b2f1fe63c&amp;client=cbc79c14efcebee57402&amp;signature=60b7c061460d0d45f5d367b8a9c62978af6b76ce">
+                                                                <figcaption><span>Devindra Hardawar/AOL</span>
+                                                                </figcaption>
+                                                            </figure>
+                                                        </div>
+                                                <div>
                                                                 <p>The console's controller hasn't changed since its
                                                                     last mini-upgrade with the Xbox One S. That revision
                                                                     rounded out its seams, improved bumper performance
@@ -41,7 +113,14 @@
                                                                     like a bad user experience when every other console
                                                                     has rechargeable controllers.</p>
                                                                 <h3>In use</h3>
-                                                            </div><div>
+                                                            </div>
+                                                <div data-engadget-breakout-type="image">
+                                                            <figure><img src="https://o.aolcdn.com/images/dims?resize=980%2C640&amp;quality=100&amp;image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D1600%252C900%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C900%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252F1885534bd201fc37481b806645c1fc8b%252F205828119%252FXbox%252Bone%252BX%252Bscreenshot%252Bgallery%252B8.jpg%26client%3Da1acac3e1b3290917d92%26signature%3Df63cf67c88b37fd9424855984e45f6b950c8c11a&amp;client=cbc79c14efcebee57402&amp;signature=0adca80fc8ee26a7353be639082881450a5ad49f">
+                                                                <figcaption><span>Devindra Hardawar/AOL</span>
+                                                                </figcaption>
+                                                            </figure>
+                                                        </div>
+                                                <div>
                                                                 <p>You won't find any major differences between the One
                                                                     X and the last Xbox at first — aside from a more
                                                                     dramatic startup sequence. Navigating the Xbox
@@ -72,7 +151,14 @@
                                                                     dip occasionally. I was also surprised that load
                                                                     times were on-par with what I've seen with the game
                                                                     on the Xbox One S.</p>
-                                                            </div><div>
+                                                            </div>
+                                                <div data-engadget-breakout-type="e2ehero">
+                                                                            <!-- article-hero -->
+                                                                            <figure><img src="https://o.aolcdn.com/images/dims?crop=1600%2C900%2C0%2C0&amp;quality=85&amp;format=jpg&amp;resize=1600%2C900&amp;image_uri=http%3A%2F%2Fo.aolcdn.com%2Fhss%2Fstorage%2Fmidas%2F8352a8a14e88e2ca2ba5be4d8381a055%2F205828115%2FXbox%2Bone%2BX%2Bscreenshot%2Bgallery%2B1.jpg&amp;client=a1acac3e1b3290917d92&amp;signature=d2ccb22e0eaabeb05bfe46e83dbe26fd07f01da8">
+                                                                                
+                                                                            </figure>
+                                                                        </div>
+                                                <div>
                                                                 <p>You can also play in Performance mode, which bumps
                                                                     the frame rate up to 60FPS and uses higher quality
                                                                     graphical effects, while rendering it lower in
@@ -97,7 +183,9 @@
                                                                     it couldn't take advantage of, in particular higher
                                                                     levels of bloom lighting and shadow detail.</p>
                                                                 <!-- inline article gal -->
-                                                            </div><section data-engadget-breakout-type="gallery">
+                                                            </div>
+                                                <!-- article-gallery-breakout -->
+                                                <section data-engadget-breakout-type="gallery">
                                                                 <h3> Gallery: Xbox
                                                                     One X screenshots | 9 Photos </h3>
                                                                 <div data-behavior="lightbox_trigger" data-engadget-slideshow-id="803330" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142924}" data-eng-mn="93511844"><p><a href="#" data-index="0" data-engadget-slide-id="7142924" data-eng-bang="{&quot;gallery&quot;:803330,&quot;slide&quot;:7142924}">
@@ -105,7 +193,8 @@
                                                                 </a></p>
                                                                     
                                                                 </div>
-                                                            </section><div>
+                                                            </section>
+                                                <div>
                                                                 <p><em>Killer Instinct</em> and <em>Super Lucky's
                                                                     Tale</em> run in 4K at a smooth 60FPS. They both
                                                                     looked and played better than their standard
@@ -137,7 +226,14 @@
                                                                     who were prescient about how they built their games.
                                                                     Basically, don't expect your entire 360 library to
                                                                     get enhanced.</p>
-                                                            </div><div>
+                                                            </div>
+                                                <div data-engadget-breakout-type="e2ehero">
+                                                                            <!-- article-hero -->
+                                                                            <figure><img src="https://o.aolcdn.com/images/dims?crop=1600%2C900%2C0%2C0&amp;quality=85&amp;format=jpg&amp;resize=1600%2C900&amp;image_uri=http%3A%2F%2Fo.aolcdn.com%2Fhss%2Fstorage%2Fmidas%2Facb08903fbe26ad77b80db8c8e7e8fb1%2F205828118%2FXbox%2Bone%2BX%2Bscreenshot%2Bgallery%2B7.jpg&amp;client=a1acac3e1b3290917d92&amp;signature=21630fa5ec6d8fdce2c35f7e1f652636a2d8efe7">
+                                                                                
+                                                                            </figure>
+                                                                        </div>
+                                                <div>
                                                                 <p>Even if a game isn't specifically tuned for the new
                                                                     console, Microsoft says you might still see some
                                                                     performance improvements. The PlayStation 4 Pro,
@@ -180,7 +276,14 @@
                                                                     Sony has had a very successful head start with the
                                                                     PlayStation VR.</p>
                                                                 <h3>Pricing and the competition</h3>
-                                                            </div><div>
+                                                            </div>
+                                                <div data-engadget-breakout-type="image">
+                                                            <figure><img src="https://o.aolcdn.com/images/dims?resize=980%2C640&amp;quality=100&amp;image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D1600%252C1027%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1027%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fa2c8ba1caccdbb9e0559797e5141eafd%252F205826078%252FXbox%252BOne%252BX%252Breview%252Bgallery%252B11.jpg%26client%3Da1acac3e1b3290917d92%26signature%3Da11bcddced805c6e3698f8ce0494102aef057265&amp;client=cbc79c14efcebee57402&amp;signature=1e9bd192add2772bc842a34e67b7572cfd1b265a">
+                                                                <figcaption><span>Devindra Hardawar/AOL</span>
+                                                                </figcaption>
+                                                            </figure>
+                                                        </div>
+                                                <div>
                                                                 <p>The biggest knock against the Xbox One X is its $500
                                                                     price. The PS4 Pro launched at $400 last year, and
                                                                     there's a good chance we'll see plenty of deals
@@ -221,28 +324,7 @@
                                                                     offer VR yet. For Microsoft fans, though, none of
                                                                     that will matter. It's exactly what the company
                                                                     promised: the fastest game console ever made.</p>
-                                                            </div><div>
-                                                            <div><p>In this article: <span>
-                    <a href="https://localhost/tag/av">av</a>,                <a href="https://localhost/tag/consoles">consoles</a>,                <a href="https://localhost/tag/entertainment">entertainment</a>,                <a href="https://localhost/tag/gadgetry">gadgetry</a>,                <a href="https://localhost/tag/gadgets">gadgets</a>,                <a href="https://localhost/tag/gaming">gaming</a>,                <a href="https://localhost/tag/gear">gear</a>,                <a href="https://localhost/tag/microsoft">microsoft</a>,                <a href="https://localhost/tag/review">review</a>,                <a href="https://localhost/tag/video">video</a>,                <a href="https://localhost/tag/videogames">videogames</a>,                <a href="https://localhost/tag/Xbox">Xbox</a>,                <a href="https://localhost/tag/XboxOne">XboxOne</a>,                <a href="https://localhost/tag/XboxOneX">XboxOneX</a>              </span>
-                                                                    </p></div>
-                                                            <div>
-                                                                <div>
-                                                                    <p><a href="https://localhost/about/editors/devindra-hardawar/">
-                                                                        <img src="https://o.aolcdn.com/images/dims?thumbnail=100%2C100&amp;quality=80&amp;image_uri=http%3A%2F%2Fwww.blogcdn.com%2Fwww.engadget.com%2Fmedia%2F2016%2F03%2Fdevindra-engadget-headshot-small.jpg&amp;client=cbc79c14efcebee57402&amp;signature=30e2e66c20e041451c3d8f10afbba87b97998f2b">
-                                                                    </a></p>
-                                                                    
-                                                                </div>
-                                                                <p>Devindra has
-                                                                    been obsessed with technology for as long as he can
-                                                                    remember -- starting with the first time he ever
-                                                                    glimpsed an NES. He spent several years fixing other
-                                                                    people's computers before he started down the
-                                                                    treacherous path of writing about technology.
-                                                                    Mission accomplished?
-                                                                </p>
                                                             </div>
-                                                            <!-- article-comments -->
-                                                            
-                                                            
-                                                            
-                                                        </div></div>
+                                                <!-- footer -->
+                                                
+                                            </div></div>


### PR DESCRIPTION
- Eliminates various (IElement) casts
- Replace SomeNode & EveryNode with Linq Any and All
- Add static to lambda invocations to help identify captured variables
- Eliminate various closure allocations / variable capturing
- Eliminate dependency on AngleSharp.Css and write non-allocation check for display:none. 
- Update alternativeCandidateAncestors to match readability.js behavior

These changes (notably the custom display:none parser)reduce my local test run time averages from ~6.2s -> ~4.8s. We also get some big reductions in GC pressure.