### PR TITLE
More robust method of obtaining visibility from style

### DIFF
--- a/src/SmartReaderTests/UtilityTests.cs
+++ b/src/SmartReaderTests/UtilityTests.cs
@@ -1,0 +1,16 @@
+﻿using SmartReader;
+using Xunit;
+
+namespace SmartReaderTests
+{
+    public class UtilityTests
+    {
+        [Fact]
+        public void TestStyleWithMultipleVisibilityTermsReturnsCorrectVisibility()
+        {
+            var style = "background-color: rgb(255, 255, 255); border: 1px solid rgb(204, 204, 204); box-shadow: rgba(0, 0, 0, 0.2) 2px 2px 3px; position: absolute; transition: visibility 0s linear 0.3s, opacity 0.3s linear 0s; opacity: 0; visibility: hidden; z-index: 2000000000; left: 0px; top: -10000px;";
+
+            Assert.Equal("hidden", NodeUtility.GetVisibilityFromStyle(style).ToString());
+        }
+    }
+}


### PR DESCRIPTION
The former method for obtaining the visibility didn't account for cases where the style contains the word `visibility` anywhere in a value. This led to IndexOutOfRange exceptions, for example with the following style:
``` css
transition: visibility 0s linear 0.3s, opacity 0.3s linear 0s; visibility: hidden;
```

The method in this PR is to be more precise about the key of the visibility style tag, and it will also ignore if the style key contains the word `visibility` but is not exactly `visibility`, e.g. `my-visibility: test`.