### PR TITLE
Automatic language detection feature

### DIFF
--- a/src/SmartReader/SmartReader.csproj
+++ b/src/SmartReader/SmartReader.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.1" />
+    <PackageReference Include="DetectLanguage" Version="1.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
### Added LanguageDetection library, DetectLanguage method, and updated tests

- Added the LanguageDetection library to the project in `SmartReader.csproj`.
- Added the `DetectLanguage` method and modified the internal constructor in `Article.cs`.
- Updated `PagesTests.cs` to test language detection, even when missing in metadata.

**Details:**
-  The library was chosen for its lightweight package size, unlike non-service-based solutions that would have unnecessarily increased project overhead.
- `DetectLanguage` method is invoked only when language metadata is absent in the HTML page.
- API key for DetectLanguage library must be set as an environment variable for method functionality, providing a free plan with 1000 requests per day and data upload limit of 1MB per day.
- Additional secret management methods may be implemented following C# specifics.

